### PR TITLE
Use new get_task functionality in tests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -9,7 +9,7 @@ jobs:
           submodules: 'true'
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: '3.8'
           cache: 'pip'
       - run: python -m pip install -r requirements.txt
       - name: Run unit tests
@@ -50,7 +50,7 @@ jobs:
           submodules: 'true'
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.8'
           cache: 'pip'
       - run: python -m pip install -r requirements.txt
       - name: Run unit tests

--- a/src/tribler/test_unit/core/libtorrent/download_manager/test_download_manager.py
+++ b/src/tribler/test_unit/core/libtorrent/download_manager/test_download_manager.py
@@ -363,9 +363,7 @@ class TestDownloadManager(TestBase):
         self.manager.start()
         await sleep(0)
 
-        for task in self.manager.get_tasks():
-            if task.get_name() == "start":
-                await task
+        await self.manager.get_task("start")
 
         self.assertTrue(self.manager.all_checkpoints_are_loaded)
 

--- a/src/tribler/test_unit/core/tunnel/test_community.py
+++ b/src/tribler/test_unit/core/tunnel/test_community.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from asyncio import TimeoutError as AsyncTimeoutError
-from asyncio import sleep, wait_for
+from asyncio import gather, sleep, wait_for
 from collections import defaultdict
 from io import BytesIO
 from typing import TYPE_CHECKING
@@ -198,9 +198,7 @@ class TestTriblerTunnelCommunity(TestBase[TriblerTunnelCommunity]):
         self.overlay(0).download_states[b'a'] = 3
 
         self.overlay(0).monitor_downloads([])
-        for task in self.overlay(0).get_tasks():
-            if task.get_name().startswith("TriblerTunnelCommunity:remove_circuit"):
-                await task
+        await gather(*self.overlay(0).get_anonymous_tasks("remove_circuit"))
 
         self.assertNotIn(0, self.overlay(0).circuits)
 
@@ -250,9 +248,7 @@ class TestTriblerTunnelCommunity(TestBase[TriblerTunnelCommunity]):
         self.overlay(0).download_states[b'a'] = 3
 
         self.overlay(0).monitor_downloads([])
-        for task in self.overlay(0).get_tasks():
-            if task.get_name().startswith("TriblerTunnelCommunity:remove_circuit"):
-                await task
+        await gather(*self.overlay(0).get_anonymous_tasks("remove_circuit"))
 
         self.assertNotIn(0, self.overlay(0).circuits)
 
@@ -271,9 +267,7 @@ class TestTriblerTunnelCommunity(TestBase[TriblerTunnelCommunity]):
         self.overlay(0).download_states[b"a"] = 3
 
         self.overlay(0).monitor_downloads([])
-        for task in self.overlay(0).get_tasks():
-            if task.get_name().startswith("TriblerTunnelCommunity:remove_circuit"):
-                await task
+        await gather(*self.overlay(0).get_anonymous_tasks("remove_circuit"))
 
         self.assertNotIn(0, self.overlay(0).circuits)
 
@@ -372,9 +366,7 @@ class TestTriblerTunnelCommunity(TestBase[TriblerTunnelCommunity]):
         await self.introduce_nodes()
         self.overlay(0).create_circuit(1, exit_flags=[PEER_FLAG_EXIT_HTTP])
         await sleep(0)
-        for task in self.overlay(1).get_tasks():
-            if task.get_name().startswith("TriblerTunnelCommunity:on_packet_from_circuit"):
-                await task
+        await gather(*self.overlay(1).get_anonymous_tasks("on_packet_from_circuit"))
 
         with patch.dict(tribler.core.tunnel.community.__dict__, {"open_connection": open_connection}),\
                 self.assertRaises(AsyncTimeoutError):


### PR DESCRIPTION
This PR:

 - Updates the IPv8 pointer.
 - Updates the tests to use `get_task` functionality.
 - Updates the Python versions for Linux and Mac Actions.

Failures:

 - Linux: `ipv8-rust-tunnels` not available on Python 3.7.
 - Mac: `libtorrent` not available on Python 3.12.
 - Validate:
 ```

set_pending_status
Github returned error "Resource not accessible by integration - https://docs.github.com/rest/commits/statuses#create-a-commit-status" when setting status on commit: 2bc1c2e9c1d60aeddfaf30f1bb5b52de4a59bfeb
 Request object:
 {
  "context": "Cross-env Validation",
  "description": "Pending..",
  "state": "pending",
  "owner": "qstokkink",
  "repo": "TriblerExperimental",
  "sha": "2bc1c2e9c1d60aeddfaf30f1bb5b52de4a59bfeb",
  "target_url": "https://github.com/qstokkink/TriblerExperimental/actions/runs/8647285243"
} Possible issues could be that the token used does not have access to the repository containing the commit or the commit/repository does not exist.

 ```
