### PR TITLE
Various fixes

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -22,4 +22,4 @@ jobs:
             **/*.py
       - name: Run ruff
         if: steps.changed-py-files.outputs.any_changed == 'true'
-        run: ruff check ${{ steps.changed-py-files.outputs.all_changed_files }}
+        run: ruff check ${{ steps.changed-py-files.outputs.all_changed_files }} --force-exclude

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -81,6 +81,7 @@ exclude = [
     "build",
     "dist",
     "node_modules",
+    "src/tribler/gui",
     "venv",
 ]
 

--- a/src/tribler/core/start_core.py
+++ b/src/tribler/core/start_core.py
@@ -2,16 +2,21 @@ from __future__ import annotations
 
 import logging.config
 from asyncio import run
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from tribler.core.session import Session
 from tribler.tribler_config import TriblerConfigManager
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 logger = logging.getLogger(__name__)
-CONFIG_FILE_NAME = 'triblerd.conf'
 
 
 async def run_session(config: TriblerConfigManager) -> None:
+    """
+    Start the Session and wait for it to shut itself down.
+    """
     session = Session(config)
     await session.start()
     await session.shutdown_event.wait()
@@ -26,7 +31,7 @@ def run_core(api_port: int, api_key: str | None, state_dir: Path) -> None:
 
     Returns an exit code value, which is non-zero if the Tribler session finished with an error.
     """
-    logger.info(f'Start tribler core. API port: "{api_port}". API key: "{api_key}". State dir: "{state_dir}".')
+    logger.info("Start tribler core. API port: %d. API key: %s. State dir: %s.", api_port, api_key, state_dir)
 
     config = TriblerConfigManager(state_dir / "configuration.json")
     config.set("state_dir", str(state_dir))

--- a/src/tribler/gui/widgets/tablecontentmodel.py
+++ b/src/tribler/gui/widgets/tablecontentmodel.py
@@ -640,6 +640,7 @@ class SearchResultsModel(ChannelContentModel):
         self.original_query = original_query
         self.remote_results = {}
         title = self.format_title()
+        kwargs["text_filter"] = original_query
         super().__init__(channel_info={"name": title}, **kwargs)
         self.remote_results_received = False
         self.postponed_remote_results = []

--- a/src/tribler/tribler_config.py
+++ b/src/tribler/tribler_config.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from json import JSONDecodeError
-from os import PathLike
 from pathlib import Path
 from typing import TypedDict
 
@@ -13,6 +13,10 @@ logger = logging.getLogger(__name__)
 
 
 class ApiConfig(TypedDict):
+    """
+    Settings for the API key component.
+    """
+
     key: str
     http_enabled: bool
     http_port: int
@@ -23,22 +27,42 @@ class ApiConfig(TypedDict):
 
 
 class ContentDiscoveryCommunityConfig(TypedDict):
+    """
+    Settings for the content discovery component.
+    """
+
     enabled: bool
 
 
 class DHTDiscoveryCommunityConfig(TypedDict):
+    """
+    Settings for the DHT discovery component.
+    """
+
     enabled: bool
 
 
 class KnowledgeCommunityConfig(TypedDict):
+    """
+    Settings for the knowledge component.
+    """
+
     enabled: bool
 
 
 class DatabaseConfig(TypedDict):
+    """
+    Settings for the database component.
+    """
+
     enabled: bool
 
 
 class DownloadDefaultsConfig(TypedDict):
+    """
+    Settings for default downloads, used by libtorrent.
+    """
+
     anonymity_enabled: bool
     number_hops: int
     safeseeding_enabled: bool
@@ -51,6 +75,10 @@ class DownloadDefaultsConfig(TypedDict):
 
 
 class LibtorrentConfig(TypedDict):
+    """
+    Settings for the libtorrent component.
+    """
+
     socks_listen_ports: list[int]
     port: int
     proxy_type: int
@@ -70,26 +98,46 @@ class LibtorrentConfig(TypedDict):
 
 
 class RendezvousConfig(TypedDict):
+    """
+    Settings for the rendezvous component.
+    """
+
     enabled: bool
 
 
 class TorrentCheckerConfig(TypedDict):
+    """
+    Settings for the torrent checker component.
+    """
+
     enabled: bool
 
 
 class TunnelCommunityConfig(TypedDict):
+    """
+    Settings for the tunnel community component.
+    """
+
     enabled: bool
     min_circuits: int
     max_circuits: int
 
 
 class UserActivityConfig(TypedDict):
+    """
+    Settings for the user activity component.
+    """
+
     enabled: bool
     max_query_history: int
     health_check_interval: float
 
 
 class TriblerConfig(TypedDict):
+    """
+    The main Tribler settings and all of its components' sub-settings.
+    """
+
     api: ApiConfig
 
     ipv8: dict
@@ -157,9 +205,11 @@ DEFAULT_CONFIG = {
     "tunnel_community": TunnelCommunityConfig(enabled=True, min_circuits=1, max_circuits=8),
     "user_activity": UserActivityConfig(enabled=True, max_query_history=500, health_check_interval=5.0),
 
-    "state_dir": ".",
+    "state_dir": str((Path(os.environ.get("APPDATA", "~")) / ".TriblerExperimental").expanduser().absolute()),
     "memory_db": False
 }
+
+# Changes to IPv8 default config
 DEFAULT_CONFIG["ipv8"]["keys"].append({
     'alias': "secondary",
     'generation': "curve25519",
@@ -167,33 +217,46 @@ DEFAULT_CONFIG["ipv8"]["keys"].append({
 })
 DEFAULT_CONFIG["ipv8"]["overlays"] = [overlay for overlay in DEFAULT_CONFIG["ipv8"]["overlays"]
                                       if overlay["class"] == "DiscoveryCommunity"]
+DEFAULT_CONFIG["ipv8"]["working_directory"] = DEFAULT_CONFIG["state_dir"]
+for key_entry in DEFAULT_CONFIG["ipv8"]["keys"]:
+    if "file" in key_entry:
+        key_entry["file"] = str(Path(DEFAULT_CONFIG["state_dir"]) / key_entry["file"])
 
 
 class TriblerConfigManager:
+    """
+    A class that interacts with a JSON configuration file.
+    """
 
     def __init__(self, config_file: Path = Path("configuration.json")) -> None:
         """
-        Load a config from a file
+        Load a config from a file.
         """
         super().__init__()
         self.config_file = config_file
 
-        logger.info(f'Load: {self.config_file}.')
+        logger.info("Load: %s.", self.config_file)
         self.configuration = {}
         if config_file.exists():
             try:
-                with open(self.config_file, "r") as f:
+                with open(self.config_file) as f:
                     self.configuration = json.load(f)
-            except JSONDecodeError as e:
+            except JSONDecodeError:
                 logger.exception("Failed to load stored configuration. Falling back to defaults!")
         if not self.configuration:
             self.configuration = DEFAULT_CONFIG
 
     def write(self) -> None:
+        """
+        Write the configuration to disk.
+        """
         with open(self.config_file, "w") as f:
             json.dump(self.configuration, f, indent=4)
 
-    def get(self, option: PathLike | str) -> dict | list | str | int | float | bool | None:
+    def get(self, option: os.PathLike | str) -> dict | list | str | float | bool | None:
+        """
+        Get a config option based on the path-like descriptor.
+        """
         out = self.configuration
         for part in Path(option).parts:
             if part in out:
@@ -206,7 +269,10 @@ class TriblerConfigManager:
                 break
         return out
 
-    def set(self, option: PathLike | str, value: dict | list | str | int | float | bool | None) -> None:
+    def set(self, option: os.PathLike | str, value: dict | list | str | float | bool | None) -> None:
+        """
+        Set a config option value based on the path-like descriptor.
+        """
         current = self.configuration
         for part in Path(option).parts[:-1]:
             current = current[part]


### PR DESCRIPTION
Fixes #5
Fixes #8

This PR:

 - Fixes all the linter issues in the affected files.
 - Fixes local search being performed without a search query. This gives random results.
 - Updates the state directory location to be in `/home/<user>` on Debian and `%APPDATA%` on Windows.
 - Updates the location of the key files to be in the state directory.
 - Updates the ruff configuration to no longer run on the GUI files.

Confirmed fix on:
 - Windows