### PR TITLE
Various fixes

### DIFF
--- a/src/tribler/core/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/torrent_checker/torrent_checker.py
@@ -90,8 +90,8 @@ class TorrentChecker(TaskManager):
         """
         Start all the looping tasks for the checker and creata socket.
         """
-        _, = self.register_task("check random tracker", self.check_random_tracker, interval=TRACKER_SELECTION_INTERVAL)
-        _, = self.register_task("check local torrents", self.check_local_torrents, interval=TORRENT_SELECTION_INTERVAL)
+        self.register_task("check random tracker", self.check_random_tracker, interval=TRACKER_SELECTION_INTERVAL)
+        self.register_task("check local torrents", self.check_local_torrents, interval=TORRENT_SELECTION_INTERVAL)
         await self.create_socket_or_schedule()
 
     async def listen_on_udp(self) -> DatagramTransport:
@@ -219,7 +219,7 @@ class TorrentChecker(TaskManager):
             self._torrents_checked = self.load_torrents_checked_from_db()
             lines = '\n'.join(f'    {health}' for health in sorted(self._torrents_checked.values(),
                                                                    key=lambda health: -health.last_check))
-            self._logger.info("Initially loaded self-checked torrents:\n%d", lines)
+            self._logger.info("Initially loaded self-checked torrents:\n%s", lines)
         return self._torrents_checked
 
     @db_session

--- a/tribler.spec
+++ b/tribler.spec
@@ -14,6 +14,8 @@ root_dir = os.path.abspath(os.path.dirname(__name__))
 src_dir = os.path.join(root_dir, "src")
 sys.path.append(src_dir)
 
+import tribler.core.components as known_components
+
 pyipv8_dir = os.path.join(root_dir, "pyipv8")
 sys.path.append(pyipv8_dir)
 
@@ -95,6 +97,7 @@ hiddenimports = [
 ]
 hiddenimports += widget_files
 hiddenimports += pony_deps
+hiddenimports += [x for member in known_components.__dict__.values() for x in getattr(member, "hiddenimports", set())]
 
 # Fix for issue: Could not load a pixbuf from icon theme.
 # Unrecognized image file format (gdk-pixbuf-error-quark, 3).


### PR DESCRIPTION
Fixes #11 
Fixes #12

This PR:

 - Fixes a crash due to assigning tasks to a variable in torrent checker.
 - Fixes a crash due to logging a string into a number in torrent checker.
 - Updates tribler.spec to find hidden imports.
