### PR TITLE
Fixed issue with the selected download state not being updated

### DIFF
--- a/src/tribler/gui/widgets/downloadspage.py
+++ b/src/tribler/gui/widgets/downloadspage.py
@@ -190,7 +190,7 @@ class DownloadsPage(QWidget):
 
         if not result:
             return
-        downloads = result.get("downloads")
+        downloads = [d for d in result.get("downloads", []) if 'pieces' in d]
         if not downloads or len(downloads) != 1:
             self._logger.warning(
                 f'Received unexpected number of downloads ({len(downloads)} instead of 1), ignoring the result.'


### PR DESCRIPTION
Currently, when you start/stop a download nothing happens until you deselect the download. This gives the impression that the download is stuck.

Apparently, the download endpoint has undergone some changes, without considering what this means for the GUI.
This PR filters out the download for which the `pieces` were requested at the GUI side, which should resurrect the old behaviour.