### PR TITLE
Various fixes

### DIFF
--- a/src/tribler/gui/event_request_manager.py
+++ b/src/tribler/gui/event_request_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import time
@@ -196,7 +197,8 @@ class EventRequestManager(QNetworkAccessManager):
             self.set_api_port(config_manager.get("api/http_port"))
 
         if self.reply is not None:
-            self.reply.deleteLater()
+            with contextlib.suppress(RuntimeError):
+                self.reply.deleteLater()
 
         # A workaround for Qt5 bug. See https://github.com/Tribler/tribler/issues/7018
         self.setNetworkAccessible(QNetworkAccessManager.Accessible)

--- a/src/tribler/tribler_config.py
+++ b/src/tribler/tribler_config.py
@@ -204,7 +204,7 @@ DEFAULT_CONFIG = {
         ),
     "rendezvous": RendezvousConfig(enabled=True),
     "torrent_checker": TorrentCheckerConfig(enabled=True),
-    "tunnel_community": TunnelCommunityConfig(enabled=True, min_circuits=1, max_circuits=8),
+    "tunnel_community": TunnelCommunityConfig(enabled=True, min_circuits=3, max_circuits=8),
     "user_activity": UserActivityConfig(enabled=True, max_query_history=500, health_check_interval=5.0),
 
     "state_dir": str((Path(os.environ.get("APPDATA", "~")) / ".TriblerExperimental").expanduser().absolute()),


### PR DESCRIPTION
Fixes #21

This PR:

 - Fixes a crash when linking the core to the GUI when requests are already destructed.
 - Updates the default minimum circuits to be 6 instead of 1. This should hopefully improve out-of-the-box anon download speeds.

