### PR TITLE
Fixed most ruff violations in the libtorrent folder

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_config.py
+++ b/src/tribler/core/libtorrent/download_manager/download_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 from io import StringIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict
 
 import libtorrent as lt
 from configobj import ConfigObj
@@ -36,26 +36,39 @@ engineresumedata = string(default='ZGU=')
 def _from_dict(value: Dict) -> str:
     binary = lt.bencode(value)
     base64_bytes = base64.b64encode(binary)
-    return base64_bytes.decode('utf-8')
+    return base64_bytes.decode()
 
 
-def _to_dict(value: str) -> Optional[Dict]:
-    binary = value.encode('utf-8')
+def _to_dict(value: str) -> dict | None:
+    binary = value.encode()
     # b'==' is added to avoid incorrect padding
-    base64_bytes = base64.b64decode(binary + b'==')
+    base64_bytes = base64.b64decode(binary + b"==")
     return lt.bdecode(base64_bytes)
 
 
 class DownloadConfig:
-    def __init__(self, config: ConfigObj | None = None):
+    """
+    A configuration belonging to a specific download.
+    """
+
+    def __init__(self, config: ConfigObj | None = None) -> None:
+        """
+        Create a download config from the given ConfigObj.
+        """
         self.config = config
 
     @staticmethod
-    def get_spec_file_name(settings: TriblerConfigManager):
+    def get_spec_file_name(settings: TriblerConfigManager) -> str:
+        """
+        Get the file name of the download spec.
+        """
         return str(Path(settings.get("state_dir")) / SPEC_FILENAME)
 
     @staticmethod
-    def from_defaults(settings: TriblerConfigManager):
+    def from_defaults(settings: TriblerConfigManager) -> DownloadConfig:
+        """
+        Create a new download config from the given Tribler configuration.
+        """
         spec_file_name = DownloadConfig.get_spec_file_name(settings)
         defaults = ConfigObj(StringIO(SPEC_CONTENT))
         defaults["filename"] = spec_file_name
@@ -71,63 +84,105 @@ class DownloadConfig:
 
         return config
 
-    def copy(self):
+    def copy(self) -> DownloadConfig:
+        """
+        Create a copy of this config.
+        """
         return DownloadConfig(ConfigObj(self.config))
 
-    def write(self, filename: Path):
+    def write(self, filename: Path) -> None:
+        """
+        Write the contents of this config to a file.
+        """
         self.config.filename = Path(filename)
         self.config.write()
 
-    def set_dest_dir(self, path: Path | str):
+    def set_dest_dir(self, path: Path | str) -> None:
         """
         Sets the directory where to save this Download.
 
         :param path: A path of a directory.
         """
-        self.config['download_defaults']['saveas'] = str(path)
+        self.config["download_defaults"]["saveas"] = str(path)
 
     def get_dest_dir(self) -> Path:
         """
         Gets the directory where to save this Download.
         """
-        dest_dir = self.config['download_defaults']['saveas']
+        dest_dir = self.config["download_defaults"]["saveas"]
         return Path(dest_dir)
 
-    def set_hops(self, hops):
-        self.config['download_defaults']['hops'] = hops
+    def set_hops(self, hops: int) -> None:
+        """
+        Set the number of hops for the download.
+        """
+        self.config["download_defaults"]["hops"] = hops
 
-    def get_hops(self):
-        return self.config['download_defaults']['hops']
+    def get_hops(self) -> int:
+        """
+        Get the set number of hops for the download.
+        """
+        return self.config["download_defaults"]["hops"]
 
-    def set_safe_seeding(self, value):
-        self.config['download_defaults']['safe_seeding'] = value
+    def set_safe_seeding(self, value: bool) -> None:
+        """
+        Set the safe seeding mode of the download.
+        """
+        self.config["download_defaults"]["safe_seeding"] = value
 
-    def get_safe_seeding(self):
-        return self.config['download_defaults']['safe_seeding']
+    def get_safe_seeding(self) -> bool:
+        """
+        Get the safe seeding mode of the download.
+        """
+        return self.config["download_defaults"]["safe_seeding"]
 
-    def set_user_stopped(self, value):
-        self.config['download_defaults']['user_stopped'] = value
+    def set_user_stopped(self, value: bool) -> None:
+        """
+        Set whether the download has been stopped by the user.
+        """
+        self.config["download_defaults"]["user_stopped"] = value
 
-    def get_user_stopped(self):
-        return self.config['download_defaults']['user_stopped']
+    def get_user_stopped(self) -> bool:
+        """
+        Get whether the download has been stopped by the user.
+        """
+        return self.config["download_defaults"]["user_stopped"]
 
-    def set_share_mode(self, value):
-        self.config['download_defaults']['share_mode'] = value
+    def set_share_mode(self, value: bool) -> None:
+        """
+        Set whether the download is in sharing mode.
+        """
+        self.config["download_defaults"]["share_mode"] = value
 
-    def get_share_mode(self):
-        return self.config['download_defaults']['share_mode']
+    def get_share_mode(self) -> bool:
+        """
+        Get whether the download is in sharing mode.
+        """
+        return self.config["download_defaults"]["share_mode"]
 
-    def set_upload_mode(self, value):
-        self.config['download_defaults']['upload_mode'] = value
+    def set_upload_mode(self, value: bool) -> None:
+        """
+        Set whether the download is in upload-only mode.
+        """
+        self.config["download_defaults"]["upload_mode"] = value
 
-    def get_upload_mode(self):
-        return self.config['download_defaults']['upload_mode']
+    def get_upload_mode(self) -> bool:
+        """
+        Get whether the download is in upload-only mode.
+        """
+        return self.config["download_defaults"]["upload_mode"]
 
-    def set_time_added(self, value):
-        self.config['download_defaults']['time_added'] = value
+    def set_time_added(self, value: int) -> None:
+        """
+        Set the UNIX timestamp for when this download was added.
+        """
+        self.config["download_defaults"]["time_added"] = value
 
-    def get_time_added(self):
-        return self.config['download_defaults']['time_added']
+    def get_time_added(self) -> int:
+        """
+        Get the UNIX timestamp for when this download was added.
+        """
+        return self.config["download_defaults"]["time_added"]
 
     def set_selected_files(self, file_indexes: list[int]) -> None:
         """
@@ -135,27 +190,48 @@ class DownloadConfig:
 
         :param file_indexes: List of file indexes as ordered in the torrent (e.g. [0,1])
         """
-        self.config['download_defaults']['selected_file_indexes'] = file_indexes
+        self.config["download_defaults"]["selected_file_indexes"] = file_indexes
 
-    def get_selected_files(self):
-        """ Returns the list of files selected for download.
-        @return A list of file indexes. """
-        return self.config['download_defaults']['selected_file_indexes']
+    def get_selected_files(self) -> list[int]:
+        """
+        Returns the list of files selected for download.
 
-    def set_bootstrap_download(self, value):
-        self.config['download_defaults']['bootstrap_download'] = value
+        :return: A list of file indexes.
+        """
+        return self.config["download_defaults"]["selected_file_indexes"]
 
-    def get_bootstrap_download(self):
-        return self.config['download_defaults']['bootstrap_download']
+    def set_bootstrap_download(self, value: bool) -> None:
+        """
+        Mark this download as a bootstrap download.
+        """
+        self.config["download_defaults"]["bootstrap_download"] = value
 
-    def set_metainfo(self, metainfo: Dict):
-        self.config['state']['metainfo'] = _from_dict(metainfo)
+    def get_bootstrap_download(self) -> bool:
+        """
+        Get whether this download is a bootstrap download.
+        """
+        return self.config["download_defaults"]["bootstrap_download"]
 
-    def get_metainfo(self) -> Optional[Dict]:
-        return _to_dict(self.config['state']['metainfo'])
+    def set_metainfo(self, metainfo: dict) -> None:
+        """
+        Set the metainfo dict for this download.
+        """
+        self.config["state"]["metainfo"] = _from_dict(metainfo)
 
-    def set_engineresumedata(self, engineresumedata: Dict):
-        self.config['state']['engineresumedata'] = _from_dict(engineresumedata)
+    def get_metainfo(self) -> dict | None:
+        """
+        Get the metainfo dict for this download or None if it cannot be decoded.
+        """
+        return _to_dict(self.config["state"]["metainfo"])
 
-    def get_engineresumedata(self) -> Optional[Dict]:
-        return _to_dict(self.config['state']['engineresumedata'])
+    def set_engineresumedata(self, engineresumedata: dict) -> None:
+        """
+        Set the engine resume data dict for this download.
+        """
+        self.config["state"]["engineresumedata"] = _from_dict(engineresumedata)
+
+    def get_engineresumedata(self) -> dict | None:
+        """
+        Get the engine resume data dict for this download or None if it cannot be decoded.
+        """
+        return _to_dict(self.config["state"]["engineresumedata"])

--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -1,38 +1,40 @@
 """
-A wrapper around libtorrent
+A wrapper around libtorrent.
 
 Author(s): Egbert Bouman
 """
 from __future__ import annotations
 
 import asyncio
-from collections import defaultdict
-from pathlib import Path
-from tempfile import TemporaryDirectory
-
-import libtorrent as lt
 import logging
 import os
 import time as timemod
 from asyncio import CancelledError, gather, iscoroutine, shield, sleep, wait_for
-from binascii import unhexlify, hexlify
+from binascii import hexlify, unhexlify
+from collections import defaultdict
 from copy import deepcopy
-from typing import Callable, Dict, List, Optional, Union
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List
 
+import libtorrent as lt
 from configobj import ConfigObj
 from ipv8.taskmanager import TaskManager
 from validate import Validator
 from yarl import URL
 
 from tribler.core.libtorrent import torrents
-from tribler.core.libtorrent.download_manager.dht_health_manager import DHTHealthManager
 from tribler.core.libtorrent.download_manager.download import Download
 from tribler.core.libtorrent.download_manager.download_config import DownloadConfig
-from tribler.core.libtorrent.download_manager.download_state import DownloadStatus
-from tribler.core.libtorrent.torrentdef import TorrentDefNoMetainfo, TorrentDef
-from tribler.core.libtorrent.uris import url_to_path, unshorten
-from tribler.core.notifier import Notifier, Notification
-from tribler.tribler_config import TriblerConfigManager
+from tribler.core.libtorrent.download_manager.download_state import DownloadState, DownloadStatus
+from tribler.core.libtorrent.torrentdef import TorrentDef, TorrentDefNoMetainfo
+from tribler.core.libtorrent.uris import unshorten, url_to_path
+from tribler.core.notifier import Notification, Notifier
+
+if TYPE_CHECKING:
+    from tribler.core.libtorrent.download_manager.dht_health_manager import DHTHealthManager
+    from tribler.core.libtorrent.torrents import TorrentFileResult
+    from tribler.tribler_config import TriblerConfigManager
 
 SOCKS5_PROXY_DEF = 2
 
@@ -53,19 +55,28 @@ DEFAULT_LT_EXTENSIONS = [
 logger = logging.getLogger(__name__)
 
 
-def encode_atp(atp):
+def encode_atp(atp: dict) -> dict:
+    """
+    Encode the "Add Torrent Params" dictionary to only include bytes, instead of strings and Paths.
+    """
     for k, v in atp.items():
         if isinstance(v, str):
-            atp[k] = v.encode('utf-8')
+            atp[k] = v.encode()
         elif isinstance(v, Path):
             atp[k] = str(v)
     return atp
 
 
 class DownloadManager(TaskManager):
+    """
+    The manager of all downloads.
+    """
 
     def __init__(self, config: TriblerConfigManager, notifier: Notifier,
                  metadata_tmpdir: TemporaryDirectory | None = None) -> None:
+        """
+        Create a new download manager.
+        """
         super().__init__()
         self.config = config
 
@@ -89,7 +100,7 @@ class DownloadManager(TaskManager):
         self.checkpoints_loaded = 0
         self.all_checkpoints_are_loaded = False
 
-        self.metadata_tmpdir = metadata_tmpdir or TemporaryDirectory(suffix='tribler_metainfo_tmpdir')
+        self.metadata_tmpdir = metadata_tmpdir or TemporaryDirectory(suffix="tribler_metainfo_tmpdir")
         # Dictionary that maps infohashes to download instances. These include only downloads that have
         # been made specifically for fetching metainfo, and will be removed afterwards.
         self.metainfo_requests = {}
@@ -98,7 +109,7 @@ class DownloadManager(TaskManager):
         self.default_alert_mask = lt.alert.category_t.error_notification | lt.alert.category_t.status_notification | \
                                   lt.alert.category_t.storage_notification | lt.alert.category_t.performance_warning | \
                                   lt.alert.category_t.tracker_notification | lt.alert.category_t.debug_notification
-        self.session_stats_callback: Optional[Callable] = None
+        self.session_stats_callback: Callable | None = None
         self.state_cb_count = 0
 
         # Status of libtorrent session to indicate if it can safely close and no pending writes to disk exists.
@@ -107,11 +118,17 @@ class DownloadManager(TaskManager):
         self.dht_readiness_timeout = config.get("libtorrent/dht_readiness_timeout")
         self._last_states_list = []
 
+    def is_shutting_down(self) -> bool:
+        """
+        Whether the download manager is currently shutting down.
+        """
+        return self._shutdown
+
     @staticmethod
     def convert_rate(rate: int) -> int:
         """
         Rate conversion due to the fact that we had a different system with Swift
-        and the old python BitTorrent core: unlimited == 0, stop == -1, else rate in kbytes
+        and the old python BitTorrent core: unlimited == 0, stop == -1, else rate in kbytes.
         """
         if rate == 0:
             return -1
@@ -123,7 +140,7 @@ class DownloadManager(TaskManager):
     def reverse_convert_rate(rate: int) -> int:
         """
         Rate conversion due to the fact that we had a different system with Swift
-        and the old python BitTorrent core: unlimited == 0, stop == -1, else rate in kbytes
+        and the old python BitTorrent core: unlimited == 0, stop == -1, else rate in kbytes.
         """
         if rate == -1:
             return 0
@@ -131,18 +148,22 @@ class DownloadManager(TaskManager):
             return -1
         return rate // 1024
 
-    async def _check_dht_ready(self, min_dht_peers=60):
+    async def _check_dht_ready(self, min_dht_peers: int = 60) -> None:
         """
         Checks whether we got enough DHT peers. If the number of DHT peers is low,
         checking for a bunch of torrents in a short period of time may result in several consecutive requests
         sent to the same peers. This can trigger those peers' flood protection mechanism,
         which results in DHT checks stuck for hours.
+
         See https://github.com/Tribler/tribler/issues/5319
         """
         while not (self.get_session() and self.get_session().status().dht_nodes > min_dht_peers):
             await asyncio.sleep(1)
 
-    def initialize(self):
+    def initialize(self) -> None:
+        """
+        Initialize the directory structure, launch the periodic tasks and start libtorrent background processes.
+        """
         # Create the checkpoints directory
         self.checkpoint_directory.mkdir(exist_ok=True)
 
@@ -155,23 +176,32 @@ class DownloadManager(TaskManager):
         if self.dht_readiness_timeout > 0 and self.config.get("libtorrent/dht"):
             self.dht_ready_task = self.register_task("check_dht_ready", self._check_dht_ready)
         self.register_task("request_torrent_updates", self._request_torrent_updates, interval=1)
-        self.register_task('task_cleanup_metacache', self._task_cleanup_metainfo_cache, interval=60, delay=0)
+        self.register_task("task_cleanup_metacache", self._task_cleanup_metainfo_cache, interval=60, delay=0)
 
         self.set_download_states_callback(self.sesscb_states_callback)
 
-    def start(self):
+    def start(self) -> None:
+        """
+        Start loading the checkpoints from disk.
+        """
         self.register_task("start", self.load_checkpoints)
 
-    def notify_shutdown_state(self, state):
-        logger.info(f'Notify shutdown state: {state}')
+    def notify_shutdown_state(self, state: str) -> None:
+        """
+        Call the notifier to signal a shutdown state update.
+        """
+        logger.info("Notify shutdown state: %s", state)
         self.notifier.notify(Notification.tribler_shutdown_state, state=state)
 
-    async def shutdown(self, timeout=30):
-        logger.info('Shutting down...')
+    async def shutdown(self, timeout: int = 30) -> None:
+        """
+        Shut down all pending tasks and background tasks.
+        """
+        logger.info("Shutting down...")
         self.cancel_pending_task("start")
         self.cancel_pending_task("download_states_lc")
         if self.downloads:
-            logger.info('Stopping downloads...')
+            logger.info("Stopping downloads...")
 
             self.notify_shutdown_state("Checkpointing Downloads...")
             await gather(*[download.stop() for download in self.downloads.values()], return_exceptions=True)
@@ -187,7 +217,7 @@ class DownloadManager(TaskManager):
             timeout -= 1
             await asyncio.sleep(1)
 
-        logger.info('Awaiting shutdown task manager...')
+        logger.info("Awaiting shutdown task manager...")
         await self.shutdown_task_manager()
 
         if self.dht_health_manager:
@@ -195,62 +225,68 @@ class DownloadManager(TaskManager):
 
         # Save libtorrent state
         if self.has_session():
-            logger.info('Saving state...')
-            with open(self.state_dir / LTSTATE_FILENAME, 'wb') as ltstate_file:
+            logger.info("Saving state...")
+            with open(self.state_dir / LTSTATE_FILENAME, "wb") as ltstate_file:  # noqa: ASYNC101
                 ltstate_file.write(lt.bencode(self.get_session().save_state()))
 
         if self.has_session() and self.config.get("libtorrent/upnp"):
-            logger.info('Stopping upnp...')
+            logger.info("Stopping upnp...")
             self.get_session().stop_upnp()
 
         # Remove metadata temporary directory
         if self.metadata_tmpdir:
-            logger.info('Removing temp directory...')
+            logger.info("Removing temp directory...")
             self.metadata_tmpdir.cleanup()
             self.metadata_tmpdir = None
-        logger.info('Shutdown completed')
+        logger.info("Shutdown completed")
 
-    def is_shutdown_ready(self):
+    def is_shutdown_ready(self) -> bool:
+        """
+        Check if the libtorrent shutdown is complete.
+        """
         return all(self.lt_session_shutdown_ready.values())
 
-    def create_session(self, hops=0):
+    def create_session(self, hops: int = 0) -> lt.session:  # noqa: PLR0912, PLR0915
+        """
+        Construct a libtorrent session for the given number of anonymization hops.
+        """
         # Due to a bug in Libtorrent 0.16.18, the outgoing_port and num_outgoing_ports value should be set in
         # the settings dictionary
-        logger.info('Creating a session')
-        settings = {'outgoing_port': 0,
-                    'num_outgoing_ports': 1,
-                    'allow_multiple_connections_per_ip': 0,
-                    'enable_upnp': int(self.config.get("libtorrent/upnp")),
-                    'enable_dht': int(self.config.get("libtorrent/dht")),
-                    'enable_lsd': int(self.config.get("libtorrent/lsd")),
-                    'enable_natpmp': int(self.config.get("libtorrent/natpmp"))}
+        logger.info("Creating a session")
+        settings = {"outgoing_port": 0,
+                    "num_outgoing_ports": 1,
+                    "allow_multiple_connections_per_ip": 0,
+                    "enable_upnp": int(self.config.get("libtorrent/upnp")),
+                    "enable_dht": int(self.config.get("libtorrent/dht")),
+                    "enable_lsd": int(self.config.get("libtorrent/lsd")),
+                    "enable_natpmp": int(self.config.get("libtorrent/natpmp"))}
 
         # Copy construct so we don't modify the default list
         extensions = list(DEFAULT_LT_EXTENSIONS)
 
-        logger.info(f'Hops: {hops}.')
+        logger.info("Hops: %d.", hops)
 
         # Elric: Strip out the -rcX, -beta, -whatever tail on the version string.
-        fingerprint = ['TL', 0, 0, 0, 0]
+        fingerprint = ["TL", 0, 0, 0, 0]
         ltsession = lt.session(lt.fingerprint(*fingerprint), flags=0) if hops == 0 else lt.session(flags=0)
 
         libtorrent_port = self.config.get("libtorrent/port")
-        logger.info(f'Libtorrent port: {libtorrent_port}')
+        logger.info("Libtorrent port: %d", libtorrent_port)
         if hops == 0:
-            settings['user_agent'] = 'Tribler/Experimental'
+            settings["user_agent"] = "Tribler/Experimental"
             enable_utp = self.config.get("libtorrent/utp")
-            settings['enable_outgoing_utp'] = enable_utp
-            settings['enable_incoming_utp'] = enable_utp
-            settings['prefer_rc4'] = True
+            settings["enable_outgoing_utp"] = enable_utp
+            settings["enable_incoming_utp"] = enable_utp
+            settings["prefer_rc4"] = True
             settings["listen_interfaces"] = f"0.0.0.0:{libtorrent_port or 6881}"
-            settings['handshake_client_version'] = f"Tribler/Experimental"
+            settings["handshake_client_version"] = "Tribler/Experimental"
         else:
-            settings['enable_outgoing_utp'] = True
-            settings['enable_incoming_utp'] = True
-            settings['enable_outgoing_tcp'] = False
-            settings['enable_incoming_tcp'] = False
-            settings['anonymous_mode'] = True
-            settings['force_proxy'] = True
+            settings["enable_outgoing_utp"] = True
+            settings["enable_incoming_utp"] = True
+            settings["enable_outgoing_tcp"] = False
+            settings["enable_incoming_tcp"] = False
+            settings["anonymous_mode"] = True
+            settings["force_proxy"] = True
 
         self.set_session_settings(ltsession, settings)
         ltsession.set_alert_mask(self.default_alert_mask)
@@ -267,19 +303,19 @@ class DownloadManager(TaskManager):
         if hops == 0:
             ltsession.listen_on(libtorrent_port, libtorrent_port + 10)
             try:
-                with open(self.state_dir / LTSTATE_FILENAME, 'rb') as fp:
+                with open(self.state_dir / LTSTATE_FILENAME, "rb") as fp:
                     lt_state = lt.bdecode(fp.read())
                 if lt_state is not None:
                     ltsession.load_state(lt_state)
                 else:
                     logger.warning("the lt.state appears to be corrupt, writing new data on shutdown")
             except Exception as exc:
-                logger.info(f"could not load libtorrent state, got exception: {exc!r}. starting from scratch")
+                logger.info("could not load libtorrent state, got exception: %s. starting from scratch", repr(exc))
         else:
             rate = DownloadManager.get_libtorrent_max_upload_rate(self.config)
             download_rate = DownloadManager.get_libtorrent_max_download_rate(self.config)
-            settings = {'upload_rate_limit': rate,
-                        'download_rate_limit': download_rate}
+            settings = {"upload_rate_limit": rate,
+                        "download_rate_limit": download_rate}
             self.set_session_settings(ltsession, settings)
 
         if self.config.get("libtorrent/dht"):
@@ -288,21 +324,28 @@ class DownloadManager(TaskManager):
                 ltsession.add_dht_router(*router)
             ltsession.start_lsd()
 
-        logger.info(f"Started libtorrent session for {hops} hops on port {ltsession.listen_port()}")
+        logger.info("Started libtorrent session for %d hops on port %d", hops, ltsession.listen_port())
         self.lt_session_shutdown_ready[hops] = False
 
         return ltsession
 
-    def has_session(self, hops=0):
+    def has_session(self, hops: int = 0) -> bool:
+        """
+        Check if we have a session for the given number of anonymization hops.
+        """
         return hops in self.ltsessions
 
-    def get_session(self, hops=0):
+    def get_session(self, hops: int = 0) -> lt.session:
+        """
+        Get the session for the given number of anonymization hops.
+        """
         if hops not in self.ltsessions:
             self.ltsessions[hops] = self.create_session(hops)
 
         return self.ltsessions[hops]
 
-    def set_proxy_settings(self, ltsession, ptype, server=None, auth=None):
+    def set_proxy_settings(self, ltsession: lt.session, ptype: int, server: tuple[str, str | int] | None = None,
+                           auth: tuple[str, str] | None = None) -> None:
         """
         Apply the proxy settings to a libtorrent session. This mechanism changed significantly in libtorrent 1.1.0.
         """
@@ -318,43 +361,61 @@ class DownloadManager(TaskManager):
             settings["proxy_password"] = auth[1]
         self.set_session_settings(ltsession, settings)
 
-    def set_max_connections(self, conns, hops=None):
-        self._map_call_on_ltsessions(hops, 'set_max_connections', conns)
+    def set_max_connections(self, conns: int, hops: int | None = None) -> None:
+        """
+        Set the maximum number of connections for the given hop count.
+        """
+        self._map_call_on_ltsessions(hops, "set_max_connections", conns)
 
-    def set_upload_rate_limit(self, rate, hops=None):
+    def set_upload_rate_limit(self, rate: int) -> None:
+        """
+        Set the upload rate limit for the given session.
+        """
         # Rate conversion due to the fact that we had a different system with Swift
         # and the old python BitTorrent core: unlimited == 0, stop == -1, else rate in kbytes
         libtorrent_rate = self.convert_rate(rate=rate)
 
         # Pass outgoing_port and num_outgoing_ports to dict due to bug in libtorrent 0.16.18
-        settings_dict = {'upload_rate_limit': libtorrent_rate, 'outgoing_port': 0, 'num_outgoing_ports': 1}
+        settings_dict = {"upload_rate_limit": libtorrent_rate, "outgoing_port": 0, "num_outgoing_ports": 1}
         for session in self.ltsessions.values():
             self.set_session_settings(session, settings_dict)
 
-    def get_upload_rate_limit(self, hops=0):
+    def get_upload_rate_limit(self, hops: int = 0) -> int:
+        """
+        Get the upload rate limit for the session with the given hop count.
+        """
         # Rate conversion due to the fact that we had a different system with Swift
         # and the old python BitTorrent core: unlimited == 0, stop == -1, else rate in kbytes
         libtorrent_rate = self.get_session(hops).upload_rate_limit()
         return self.reverse_convert_rate(rate=libtorrent_rate)
 
-    def set_download_rate_limit(self, rate, hops=None):
+    def set_download_rate_limit(self, rate: int) -> None:
+        """
+        Set the download rate limit for the given session.
+        """
         libtorrent_rate = self.convert_rate(rate=rate)
 
         # Pass outgoing_port and num_outgoing_ports to dict due to bug in libtorrent 0.16.18
-        settings_dict = {'download_rate_limit': libtorrent_rate}
+        settings_dict = {"download_rate_limit": libtorrent_rate}
         for session in self.ltsessions.values():
             self.set_session_settings(session, settings_dict)
 
-    def get_download_rate_limit(self, hops=0):
+    def get_download_rate_limit(self, hops: int = 0) -> int:
+        """
+        Get the download rate limit for the session with the given hop count.
+        """
         libtorrent_rate = self.get_session(hops=hops).download_rate_limit()
         return self.reverse_convert_rate(rate=libtorrent_rate)
 
-    def process_alert(self, alert, hops=0):
+    def process_alert(self, alert, hops: int = 0) -> None:  # noqa: C901, PLR0912
+        """
+        Process a libtorrent alert.
+        """
         alert_type = alert.__class__.__name__
 
         # Periodically, libtorrent will send us a state_update_alert, which contains the torrent status of
         # all torrents changed since the last time we received this alert.
-        if alert_type == 'state_update_alert':
+        if alert_type == "state_update_alert":
             for status in alert.status:
                 infohash = status.info_hash.to_bytes()
                 if infohash not in self.downloads:
@@ -362,20 +423,20 @@ class DownloadManager(TaskManager):
                     continue
                 self.downloads[infohash].update_lt_status(status)
 
-        if alert_type == 'state_changed_alert':
+        if alert_type == "state_changed_alert":
             infohash = alert.handle.info_hash().to_bytes()
             if infohash not in self.downloads:
                 logger.debug("Got state_change for unknown torrent %s", hexlify(infohash))
             else:
                 self.downloads[infohash].update_lt_status(alert.handle.status())
 
-        infohash = (alert.handle.info_hash().to_bytes() if hasattr(alert, 'handle') and alert.handle.is_valid()
-                    else getattr(alert, 'info_hash', b''))
+        infohash = (alert.handle.info_hash().to_bytes() if hasattr(alert, "handle") and alert.handle.is_valid()
+                    else getattr(alert, "info_hash", b""))
         download = self.downloads.get(infohash)
         if download:
             is_process_alert = (download.handle and download.handle.is_valid()) \
-                               or (not download.handle and alert_type == 'add_torrent_alert') \
-                               or (download.handle and alert_type == 'torrent_removed_alert')
+                               or (not download.handle and alert_type == "add_torrent_alert") \
+                               or (download.handle and alert_type == "torrent_removed_alert")
             if is_process_alert:
                 download.process_alert(alert, alert_type)
             else:
@@ -383,16 +444,16 @@ class DownloadManager(TaskManager):
         elif infohash:
             logger.debug("Got alert for unknown download %s: %s", infohash, alert)
 
-        if alert_type == 'listen_succeeded_alert':
+        if alert_type == "listen_succeeded_alert":
             self.listen_ports[hops][alert.address] = alert.port
 
-        elif alert_type == 'peer_disconnected_alert':
+        elif alert_type == "peer_disconnected_alert":
             self.notifier.notify(Notification.peer_disconnected, peer_id=alert.pid.to_bytes())
 
-        elif alert_type == 'session_stats_alert':
-            queued_disk_jobs = alert.values['disk.queued_disk_jobs']
-            queued_write_bytes = alert.values['disk.queued_write_bytes']
-            num_write_jobs = alert.values['disk.num_write_jobs']
+        elif alert_type == "session_stats_alert":
+            queued_disk_jobs = alert.values["disk.queued_disk_jobs"]
+            queued_write_bytes = alert.values["disk.queued_write_bytes"]
+            num_write_jobs = alert.values["disk.num_write_jobs"]
             if queued_disk_jobs == queued_write_bytes == num_write_jobs == 0:
                 self.lt_session_shutdown_ready[hops] = True
 
@@ -402,33 +463,36 @@ class DownloadManager(TaskManager):
         elif alert_type == "dht_pkt_alert":
             # Unfortunately, the Python bindings don't have a direction attribute.
             # So, we'll have to resort to using the string representation of the alert instead.
-            incoming = str(alert).startswith('<==')
+            incoming = str(alert).startswith("<==")
             decoded = lt.bdecode(alert.pkt_buf)
             if not decoded:
                 return
 
             # We are sending a raw DHT message - notify the DHTHealthManager of the outstanding request.
-            if not incoming and decoded.get(b'y') == b'q' \
-                    and decoded.get(b'q') == b'get_peers' and decoded[b'a'].get(b'scrape') == 1:
-                self.dht_health_manager.requesting_bloomfilters(decoded[b't'],
-                                                                decoded[b'a'][b'info_hash'])
+            if not incoming and decoded.get(b"y") == b"q" \
+                    and decoded.get(b"q") == b"get_peers" and decoded[b"a"].get(b"scrape") == 1:
+                self.dht_health_manager.requesting_bloomfilters(decoded[b"t"],
+                                                                decoded[b"a"][b"info_hash"])
 
             # We received a raw DHT message - decode it and check whether it is a BEP33 message.
-            if incoming and b'r' in decoded and b'BFsd' in decoded[b'r'] and b'BFpe' in decoded[b'r']:
-                self.dht_health_manager.received_bloomfilters(decoded[b't'],
-                                                              bytearray(decoded[b'r'][b'BFsd']),
-                                                              bytearray(decoded[b'r'][b'BFpe']))
+            if incoming and b"r" in decoded and b"BFsd" in decoded[b"r"] and b"BFpe" in decoded[b"r"]:
+                self.dht_health_manager.received_bloomfilters(decoded[b"t"],
+                                                              bytearray(decoded[b"r"][b"BFsd"]),
+                                                              bytearray(decoded[b"r"][b"BFpe"]))
 
-    def update_ip_filter(self, lt_session, ip_addresses):
-        logger.debug('Updating IP filter %s', ip_addresses)
+    def update_ip_filter(self, lt_session: lt.session, ip_addresses: Iterable[str]) -> None:
+        """
+        Add illegal IPs to libtorrent.
+        """
+        logger.debug("Updating IP filter %s", ip_addresses)
         ip_filter = lt.ip_filter()
-        ip_filter.add_rule('0.0.0.0', '255.255.255.255', 1)
+        ip_filter.add_rule("0.0.0.0", "255.255.255.255", 1)
         for ip in ip_addresses:
             ip_filter.add_rule(ip, ip, 0)
         lt_session.set_ip_filter(ip_filter)
 
-    async def get_metainfo(self, infohash: bytes, timeout: float = 7, hops: Optional[int] = None,
-                           url: str | None = None, raise_errors: bool = False) -> Optional[Dict]:
+    async def get_metainfo(self, infohash: bytes, timeout: float = 7, hops: int | None = None,
+                           url: str | None = None, raise_errors: bool = False) -> dict | None:
         """
         Lookup metainfo for a given infohash. The mechanism works by joining the swarm for the infohash connecting
         to a few peers, and downloading the metadata for the torrent.
@@ -441,17 +505,17 @@ class DownloadManager(TaskManager):
         """
         infohash_hex = hexlify(infohash)
         if infohash in self.metainfo_cache:
-            logger.info('Returning metainfo from cache for %s', infohash_hex)
-            return self.metainfo_cache[infohash]['meta_info']
+            logger.info("Returning metainfo from cache for %s", infohash_hex)
+            return self.metainfo_cache[infohash]["meta_info"]
 
-        logger.info('Trying to fetch metainfo for %s', infohash_hex)
+        logger.info("Trying to fetch metainfo for %s", infohash_hex)
         if infohash in self.metainfo_requests:
             download = self.metainfo_requests[infohash][0]
             self.metainfo_requests[infohash][1] += 1
         elif infohash in self.downloads:
             download = self.downloads[infohash]
         else:
-            tdef = TorrentDefNoMetainfo(infohash, b'metainfo request', url=url)
+            tdef = TorrentDefNoMetainfo(infohash, b"metainfo request", url=url)
             dcfg = DownloadConfig.from_defaults(self.config)
             dcfg.set_hops(hops or self.config.get("libtorrent/download_defaults/number_hops"))
             dcfg.set_upload_mode(True)  # Upload mode should prevent libtorrent from creating files
@@ -461,21 +525,21 @@ class DownloadManager(TaskManager):
             except TypeError as e:
                 logger.warning(e)
                 if raise_errors:
-                    raise e
+                    raise
                 return None
             self.metainfo_requests[infohash] = [download, 1]
 
         try:
             metainfo = download.tdef.get_metainfo() or await wait_for(shield(download.future_metainfo), timeout)
         except (CancelledError, asyncio.TimeoutError) as e:
-            logger.warning(f'{type(e).__name__}: {e} (timeout={timeout})')
-            logger.info('Failed to retrieve metainfo for %s', infohash_hex)
+            logger.warning("%s: %s (timeout=%f)", type(e).__name__, str(e), timeout)
+            logger.info("Failed to retrieve metainfo for %s", infohash_hex)
             if raise_errors:
-                raise e
+                raise
             return None
 
-        logger.info('Successfully retrieved metainfo for %s', infohash_hex)
-        self.metainfo_cache[infohash] = {'time': timemod.time(), 'meta_info': metainfo}
+        logger.info("Successfully retrieved metainfo for %s", infohash_hex)
+        self.metainfo_cache[infohash] = {"time": timemod.time(), "meta_info": metainfo}
 
         if infohash in self.metainfo_requests:
             self.metainfo_requests[infohash][1] -= 1
@@ -485,44 +549,47 @@ class DownloadManager(TaskManager):
 
         return metainfo
 
-    def _task_cleanup_metainfo_cache(self):
+    def _task_cleanup_metainfo_cache(self) -> None:
         oldest_time = timemod.time() - METAINFO_CACHE_PERIOD
 
         for info_hash, cache_entry in list(self.metainfo_cache.items()):
-            last_time = cache_entry['time']
+            last_time = cache_entry["time"]
             if last_time < oldest_time:
                 del self.metainfo_cache[info_hash]
 
-    def _request_torrent_updates(self):
+    def _request_torrent_updates(self) -> None:
         for ltsession in self.ltsessions.values():
             if ltsession:
                 ltsession.post_torrent_updates(0xffffffff)
 
-    def _task_process_alerts(self):
+    def _task_process_alerts(self) -> None:
         for hops, ltsession in list(self.ltsessions.items()):
             if ltsession:
                 for alert in ltsession.pop_alerts():
                     self.process_alert(alert, hops=hops)
 
-    def _map_call_on_ltsessions(self, hops, funcname, *args, **kwargs):
+    def _map_call_on_ltsessions(self, hops: int | None, funcname: str, *args: Any, **kwargs) -> None:  # noqa: ANN401
         if hops is None:
             for session in self.ltsessions.values():
                 getattr(session, funcname)(*args, **kwargs)
         else:
             getattr(self.get_session(hops), funcname)(*args, **kwargs)
 
-    async def start_download_from_uri(self, uri, config=None):
-        logger.info(f'Start download from URI: {uri}')
+    async def start_download_from_uri(self, uri: str, config: DownloadConfig | None = None) -> Download:
+        """
+        Start a download from the given uri.
+        """
+        logger.info("Start download from URI: %s", uri)
 
         uri = await unshorten(uri)
         scheme = URL(uri).scheme
 
         if scheme in ("http", "https"):
-            logger.info('Http(s) scheme detected')
+            logger.info("Http(s) scheme detected")
             tdef = await TorrentDef.load_from_url(uri)
             return await self.start_download(tdef=tdef, config=config)
         if scheme == "magnet":
-            logger.info('Magnet scheme detected')
+            logger.info("Magnet scheme detected")
             params = lt.parse_magnet_uri(uri)
             try:
                 # libtorrent 1.2.19
@@ -531,33 +598,39 @@ class DownloadManager(TaskManager):
                 # libtorrent 2.0.9
                 name = params.name.encode()
                 infohash = unhexlify(str(params.info_hash))
-            logger.info(f'Name: {name}. Infohash: {infohash}')
+            logger.info("Name: %s. Infohash: %s", name, infohash)
             if infohash in self.metainfo_cache:
-                logger.info('Metainfo found in cache')
-                tdef = TorrentDef.load_from_dict(self.metainfo_cache[infohash]['meta_info'])
+                logger.info("Metainfo found in cache")
+                tdef = TorrentDef.load_from_dict(self.metainfo_cache[infohash]["meta_info"])
             else:
                 logger.info("Metainfo not found in cache")
-                tdef = TorrentDefNoMetainfo(infohash, b"Unknown name" if not name else name, url=uri)
+                tdef = TorrentDefNoMetainfo(infohash, name if name else b"Unknown name", url=uri)
             return await self.start_download(tdef=tdef, config=config)
         if scheme == "file":
-            logger.info('File scheme detected')
+            logger.info("File scheme detected")
             file = url_to_path(uri)
             return await self.start_download(torrent_file=file, config=config)
-        raise Exception("invalid uri")
+        msg = "invalid uri"
+        raise Exception(msg)
 
-    async def start_download(self, torrent_file=None, tdef=None, config: DownloadConfig = None,
-                             checkpoint_disabled=False, hidden=False) -> Download:
-        logger.info(f'Starting download: filename: {torrent_file}, torrent def: {tdef}')
+    async def start_download(self, torrent_file: str | None = None, tdef: TorrentDef | None = None,
+                             config: DownloadConfig | None = None,
+                             checkpoint_disabled: bool = False, hidden: bool = False) -> Download:
+        """
+        Start a download from the given information.
+        """
+        logger.info("Starting download: filename: %s, torrent def: %s", str(torrent_file), str(tdef))
         if config is None:
             config = DownloadConfig.from_defaults(self.config)
-            logger.info('Use a default config.')
+            logger.info("Use a default config.")
 
         # the priority of the parameters is: (1) tdef, (2) torrent_file.
         # so if we have tdef, and torrent_file will be ignored, and so on.
         if tdef is None:
-            logger.info('Torrent def is None. Trying to load it from torrent file.')
+            logger.info("Torrent def is None. Trying to load it from torrent file.")
             if torrent_file is None:
-                raise ValueError("Torrent file must be provided if tdef is not given")
+                msg = "Torrent file must be provided if tdef is not given"
+                raise ValueError(msg)
             # try to get the torrent from the given torrent file
             tdef = await TorrentDef.load(torrent_file)
 
@@ -567,10 +640,10 @@ class DownloadManager(TaskManager):
         download = self.get_download(infohash)
 
         if download and infohash not in self.metainfo_requests:
-            logger.info('Download exists and metainfo is not requested.')
+            logger.info("Download exists and metainfo is not requested.")
             new_trackers = list(tdef.get_trackers() - download.get_def().get_trackers())
             if new_trackers:
-                logger.info(f'New trackers: {new_trackers}')
+                logger.info("New trackers: %s", str(new_trackers))
                 self.update_trackers(tdef.get_infohash(), new_trackers)
             return download
 
@@ -578,7 +651,7 @@ class DownloadManager(TaskManager):
         try:
             destination_directory = config.get_dest_dir()
             if not destination_directory.is_dir():
-                logger.info(f'Destination directory does not exist. Creating it: {destination_directory}')
+                logger.info("Destination directory does not exist. Creating it: %s", str(destination_directory))
                 os.makedirs(destination_directory)
         except OSError:
             logger.exception("Unable to create the download destination directory.")
@@ -594,26 +667,29 @@ class DownloadManager(TaskManager):
                             notifier=self.notifier,
                             state_dir=self.state_dir,
                             download_manager=self)
-        logger.info(f'Download created: {download}')
+        logger.info("Download created: %s", str(download))
         atp = download.get_atp()
         logger.info("ATP: %s", str({k: v for k, v in atp.items() if k not in ["resume_data"]}))
         # Keep metainfo downloads in self.downloads for now because we will need to remove it later,
         # and removing the download at this point will stop us from receiving any further alerts.
         if infohash not in self.metainfo_requests or self.metainfo_requests[infohash][0] == download:
-            logger.info('Metainfo is not requested or download is the first in the queue.')
+            logger.info("Metainfo is not requested or download is the first in the queue.")
             self.downloads[infohash] = download
-        logger.info('Starting handle.')
+        logger.info("Starting handle.")
         await self.start_handle(download, atp)
         return download
 
-    async def start_handle(self, download, atp):
+    async def start_handle(self, download: Download, atp: dict) -> None:
+        """
+        Create and start the libtorrent handle for the given download.
+        """
         atp_resume_data_skipped = atp.copy()
-        resume_data = atp.get('resume_data')
+        resume_data = atp.get("resume_data")
         if resume_data:
-            atp_resume_data_skipped['resume_data'] = '<skipped in log>'
-        logger.info(f"Start handle. Download: {download}. Atp: {atp_resume_data_skipped}")
+            atp_resume_data_skipped["resume_data"] = "<skipped in log>"
+        logger.info("Start handle. Download: %s. Atp: %s", str(download), str(atp_resume_data_skipped))
         if resume_data:
-            logger.debug(f"Download resume data: {atp['resume_data']}")
+            logger.debug("Download resume data: %s", str(atp["resume_data"]))
 
         ltsession = self.get_session(download.config.get_hops())
         infohash = download.get_def().get_infohash()
@@ -630,13 +706,13 @@ class DownloadManager(TaskManager):
         if existing_handle:
             # Reuse existing handle
             logger.debug("Reusing handle %s", hexlify(infohash))
-            download.post_alert('add_torrent_alert', {"handle": existing_handle})
+            download.post_alert("add_torrent_alert", {"handle": existing_handle})
         else:
             # Otherwise, add it anew
             _ = self.replace_task(f"AddTorrent{infohash}", self._async_add_torrent, ltsession, infohash, atp,
                                   ignore=(Exception,))
 
-    async def _async_add_torrent(self, ltsession, infohash, atp):
+    async def _async_add_torrent(self, ltsession: lt.session, infohash: bytes , atp: dict) -> None:
         self._logger.debug("Adding handle %s", hexlify(infohash))
         # To prevent flooding the DHT with a short burst of queries and triggering
         # flood protection, we postpone adding torrents until we get enough DHT peers.
@@ -652,20 +728,22 @@ class DownloadManager(TaskManager):
                 self._logger.warning("Timeout waiting for libtorrent DHT getting enough peers")
         ltsession.async_add_torrent(encode_atp(atp))
 
-    def get_libtorrent_version(self):
+    def get_libtorrent_version(self) -> str:
+        """
+        Get the libtorrent version.
+        """
         try:
             return lt.__version__
         except AttributeError:
             return lt.version
 
-    def set_session_settings(self, lt_session, new_settings):
+    def set_session_settings(self, lt_session: lt.session, new_settings: dict) -> None:
         """
         Apply/set new sessions in a libtorrent session.
 
         :param lt_session: The libtorrent session to apply the settings to.
         :param new_settings: The new settings to apply.
         """
-
         # Keeping a copy of the settings because subsequent calls to get_settings are likely to fail
         # when libtorrent will try to decode peer_fingerprint to unicode.
         if lt_session not in self.ltsettings:
@@ -677,13 +755,17 @@ class DownloadManager(TaskManager):
                 lt_session.apply_settings(new_settings)
             else:
                 lt_session.set_settings(new_settings)
-        except OverflowError:
-            raise OverflowError(f"Overflow error when setting libtorrent sessions with settings: {new_settings}")
+        except OverflowError as e:
+            msg = f"Overflow error when setting libtorrent sessions with settings: {new_settings}"
+            raise OverflowError(msg) from e
 
-    def get_session_settings(self, lt_session):
+    def get_session_settings(self, lt_session: lt.session) -> dict:
+        """
+        Get a copy of the libtorrent settings for the given session.
+        """
         return deepcopy(self.ltsettings.get(lt_session, {}))
 
-    def update_max_rates_from_config(self):
+    def update_max_rates_from_config(self) -> None:
         """
         Set the maximum download and maximum upload rate limits with the value in the config.
 
@@ -693,16 +775,23 @@ class DownloadManager(TaskManager):
         for lt_session in self.ltsessions.values():
             rate = DownloadManager.get_libtorrent_max_upload_rate(self.config)
             download_rate = DownloadManager.get_libtorrent_max_download_rate(self.config)
-            settings = {'download_rate_limit': download_rate,
-                        'upload_rate_limit': rate}
+            settings = {"download_rate_limit": download_rate,
+                        "upload_rate_limit": rate}
             self.set_session_settings(lt_session, settings)
 
-    def post_session_stats(self):
-        logger.info('Post session stats')
+    def post_session_stats(self) -> None:
+        """
+        Gather statistics and cause a ``session_stats_alert``.
+        """
+        logger.info("Post session stats")
         for session in self.ltsessions.values():
             session.post_session_stats()
 
-    async def remove_download(self, download, remove_content=False, remove_checkpoint=True):
+    async def remove_download(self, download: Download, remove_content: bool = False,
+                              remove_checkpoint: bool = True) -> None:
+        """
+        Remove a download and optionally also remove the downloaded file(s) and checkpoint.
+        """
         infohash = download.get_def().get_infohash()
         handle = download.handle
 
@@ -727,16 +816,25 @@ class DownloadManager(TaskManager):
         else:
             logger.debug("Cannot remove unknown download")
 
-    def get_download(self, infohash: bytes) -> Download:
+    def get_download(self, infohash: bytes) -> Download | None:
+        """
+        Get the download belonging to a given infohash.
+        """
         return self.downloads.get(infohash, None)
 
     def get_downloads(self) -> List[Download]:
+        """
+        Get a list of all known downloads.
+        """
         return list(self.downloads.values())
 
-    def download_exists(self, infohash):
+    def download_exists(self, infohash: bytes) -> bool:
+        """
+        Check if there is a download with a given infohash.
+        """
         return infohash in self.downloads
 
-    async def update_hops(self, download, new_hops):
+    async def update_hops(self, download: Download, new_hops: int) -> None:
         """
         Update the amount of hops for a specified download. This can be done on runtime.
         """
@@ -753,7 +851,7 @@ class DownloadManager(TaskManager):
 
         await self.start_download(tdef=download.tdef, config=config)
 
-    def update_trackers(self, infohash, trackers):
+    def update_trackers(self, infohash: bytes, trackers: list[str]) -> None:
         """
         Update the trackers for a download.
 
@@ -788,7 +886,7 @@ class DownloadManager(TaskManager):
                 download.set_def(new_def)
                 download.checkpoint()
 
-    def set_download_states_callback(self, user_callback, interval=1.0):
+    def set_download_states_callback(self, user_callback, interval: float = 1.0) -> None:
         """
         Set the download state callback. Remove any old callback if it's present.
         Calls user_callback with a list of
@@ -804,7 +902,7 @@ class DownloadManager(TaskManager):
         logger.debug("Starting the download state callback with interval %f", interval)
         self.replace_task("download_states_lc", self._invoke_states_cb, user_callback, interval=interval)
 
-    async def _invoke_states_cb(self, callback):
+    async def _invoke_states_cb(self, callback) -> None:
         """
         Invoke the download states callback with a list of the download states.
         """
@@ -812,7 +910,7 @@ class DownloadManager(TaskManager):
         if iscoroutine(result):
             await result
 
-    async def sesscb_states_callback(self, states_list):
+    async def sesscb_states_callback(self, states_list: list[DownloadState]) -> None:
         """
         This method is periodically (every second) called with a list of the download states of the active downloads.
         """
@@ -822,29 +920,35 @@ class DownloadManager(TaskManager):
             download = ds.get_download()
             infohash = download.get_def().get_infohash()
 
-            if ds.get_status() == DownloadStatus.SEEDING:
-                if download.config.get_hops() == 0 and download.config.get_safe_seeding():
-                    # Re-add the download with anonymity enabled
-                    hops = self.config.get("libtorrent/download_defaults/number_hops")
-                    await self.update_hops(download, hops)
+            if (ds.get_status() == DownloadStatus.SEEDING and download.config.get_hops() == 0
+                    and download.config.get_safe_seeding()):
+                # Re-add the download with anonymity enabled
+                hops = self.config.get("libtorrent/download_defaults/number_hops")
+                await self.update_hops(download, hops)
 
             # Check the peers of this download every five seconds and add them to the payout manager when
             # this peer runs a Tribler instance
             if self.state_cb_count % 5 == 0 and download.config.get_hops() == 0 and self.notifier:
                 for peer in download.get_peer_list():
-                    if str(peer["extended_version"]).startswith('Tribler'):
+                    if str(peer["extended_version"]).startswith("Tribler"):
                         self.notifier.notify(Notification.tribler_torrent_peer_update,
                                              peer_id=unhexlify(peer["id"]), infohash=infohash, balance=peer["dtotal"])
 
         if self.state_cb_count % 4 == 0:
             self._last_states_list = states_list
 
-    def get_last_download_states(self):
+    def get_last_download_states(self) -> list[DownloadState]:
+        """
+        Get the last download states.
+        """
         return self._last_states_list
 
-    async def load_checkpoints(self):
+    async def load_checkpoints(self) -> None:
+        """
+        Load the checkpoint files in the checkpoint directory.
+        """
         self._logger.info("Load checkpoints...")
-        checkpoint_filenames = list(self.get_checkpoint_dir().glob('*.conf'))
+        checkpoint_filenames = list(self.get_checkpoint_dir().glob("*.conf"))
         self.checkpoints_count = len(checkpoint_filenames)
         for i, filename in enumerate(checkpoint_filenames, start=1):
             await self.load_checkpoint(filename)
@@ -853,7 +957,10 @@ class DownloadManager(TaskManager):
         self.all_checkpoints_are_loaded = True
         self._logger.info("Checkpoints are loaded")
 
-    async def load_checkpoint(self, filename) -> bool:
+    async def load_checkpoint(self, filename: str) -> bool:
+        """
+        Load a checkpoint from a given file name.
+        """
         try:
             conf_obj = ConfigObj(str(filename), configspec=DownloadConfig.get_spec_file_name(self.config))
             conf_obj.validate(Validator())
@@ -872,16 +979,16 @@ class DownloadManager(TaskManager):
             return False
 
         try:
-            url = metainfo.get(b'url')
+            url = metainfo.get(b"url")
             url = url.decode() if url is not None else url
-            tdef = (TorrentDefNoMetainfo(metainfo[b'infohash'], metainfo[b'name'], url)
-                    if b'infohash' in metainfo else TorrentDef.load_from_dict(metainfo))
+            tdef = (TorrentDefNoMetainfo(metainfo[b"infohash"], metainfo[b"name"], url)
+                    if b"infohash" in metainfo else TorrentDef.load_from_dict(metainfo))
         except (KeyError, ValueError) as e:
             self._logger.exception("Could not restore tdef from metainfo dict: %s %s ", e, metainfo)
             return False
 
         config.state_dir = self.state_dir
-        if config.get_dest_dir() == '':  # removed torrent ignoring
+        if config.get_dest_dir() == "":  # removed torrent ignoring
             self._logger.info("Removing checkpoint %s destdir is %s", filename, config.get_dest_dir())
             os.remove(filename)
             return False
@@ -896,10 +1003,13 @@ class DownloadManager(TaskManager):
             self._logger.exception("Not resuming checkpoint due to exception while adding download")
         return False
 
-    def remove_config(self, infohash):
+    def remove_config(self, infohash: bytes) -> None:
+        """
+        Remove the configuration for the download belonging to the given infohash.
+        """
         if infohash not in self.downloads:
             try:
-                basename = hexlify(infohash).decode() + '.conf'
+                basename = hexlify(infohash).decode() + ".conf"
                 filename = self.get_checkpoint_dir() / basename
                 self._logger.debug("Removing download checkpoint %s", filename)
                 if os.access(filename, os.F_OK):
@@ -910,30 +1020,34 @@ class DownloadManager(TaskManager):
         else:
             self._logger.warning("Download is back, restarted? Cancelling removal! %s", hexlify(infohash))
 
-    def get_checkpoint_dir(self):
+    def get_checkpoint_dir(self) -> Path:
         """
         Returns the directory in which to checkpoint the Downloads in this Session.
         """
         return self.state_dir / "dlcheckpoints"
 
     @staticmethod
-    async def create_torrent_file(file_path_list, params=None):
+    async def create_torrent_file(file_path_list: list[str], params: dict | None = None) -> TorrentFileResult:
         """
         Creates a torrent file.
 
         :param file_path_list: files to add in torrent file
         :param params: optional parameters for torrent file
-        :return: a Deferred that fires when the torrent file has been created
         """
         return await asyncio.get_event_loop().run_in_executor(None, torrents.create_torrent_file,
                                                               file_path_list, params or {})
 
-    def get_downloads_by_name(self, torrent_name):
+    def get_downloads_by_name(self, torrent_name: str) -> list[Download]:
+        """
+        Get all downloads for which the UTF-8 name equals the given string.
+        """
         downloads = self.get_downloads()
         return [d for d in downloads if d.get_def().get_name_utf8() == torrent_name]
 
     @staticmethod
-    def set_libtorrent_proxy_settings(config: TriblerConfigManager, proxy_type, server=None, auth=None):
+    def set_libtorrent_proxy_settings(config: TriblerConfigManager, proxy_type: int,
+                                      server: tuple[str, int] | None = None,
+                                      auth: tuple[str, str] | None = None) -> None:
         """
         Set which proxy LibTorrent should use (default = 0).
 
@@ -948,20 +1062,23 @@ class DownloadManager(TaskManager):
         :param auth: (username, password) tuple or None
         """
         config.set("libtorrent/proxy_type", proxy_type)
-        config.set("libtorrent/proxy_server", server if proxy_type else ':')
-        config.set("libtorrent/proxy_auth", auth if proxy_type in [3, 5] else ':')
+        config.set("libtorrent/proxy_server", server if proxy_type else ":")
+        config.set("libtorrent/proxy_auth", auth if proxy_type in [3, 5] else ":")
 
-    def get_libtorrent_proxy_settings(self):
+    def get_libtorrent_proxy_settings(self) -> tuple[int, tuple[str, str] | None, tuple[str, str] | None]:
+        """
+        Get the settings for the libtorrent proxy.
+        """
         proxy_server = str(self.config.get("libtorrent/proxy_server"))
-        proxy_server = proxy_server.split(':') if proxy_server else None
+        proxy_server = proxy_server.split(":") if proxy_server else None
 
         proxy_auth = str(self.config.get("libtorrent/proxy_auth"))
-        proxy_auth = proxy_auth.split(':') if proxy_auth else None
+        proxy_auth = proxy_auth.split(":") if proxy_auth else None
 
         return self.config.get("libtorrent/proxy_type"), proxy_server, proxy_auth
 
     @staticmethod
-    def get_libtorrent_max_upload_rate(config: TriblerConfigManager):
+    def get_libtorrent_max_upload_rate(config: TriblerConfigManager) -> float:
         """
         Gets the maximum upload rate (kB / s).
 
@@ -970,7 +1087,7 @@ class DownloadManager(TaskManager):
         return min(config.get("libtorrent/max_upload_rate"), 2147483647)
 
     @staticmethod
-    def get_libtorrent_max_download_rate(config: TriblerConfigManager):
+    def get_libtorrent_max_download_rate(config: TriblerConfigManager) -> float:
         """
         Gets the maximum download rate (kB / s).
 

--- a/src/tribler/core/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/downloads_endpoint.py
@@ -1,19 +1,23 @@
-from asyncio import CancelledError, TimeoutError as AsyncTimeoutError, wait_for
-from binascii import unhexlify, hexlify
+from __future__ import annotations
+
+from asyncio import CancelledError, wait_for
+from asyncio import TimeoutError as AsyncTimeoutError
+from binascii import hexlify, unhexlify
 from contextlib import suppress
-from pathlib import PurePosixPath, Path
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, TypedDict
 
 import libtorrent as lt
 from aiohttp import web
 from aiohttp_apispec import docs, json_schema
-from ipv8.REST.schema import schema
 from ipv8.messaging.anonymization.tunnel import PEER_FLAG_EXIT_BT
+from ipv8.REST.schema import schema
 from marshmallow.fields import Boolean, Float, Integer, List, String
 
 from tribler.core.libtorrent.download_manager.download import Download, IllegalFileIndex
 from tribler.core.libtorrent.download_manager.download_config import DownloadConfig
 from tribler.core.libtorrent.download_manager.download_manager import DownloadManager
-from tribler.core.libtorrent.download_manager.download_state import DownloadStatus, DOWNLOAD, UPLOAD
+from tribler.core.libtorrent.download_manager.download_state import DOWNLOAD, UPLOAD, DownloadStatus
 from tribler.core.libtorrent.download_manager.stream import STREAM_PAUSE_TIME, StreamChunk
 from tribler.core.restapi.rest_endpoint import (
     HTTP_BAD_REQUEST,
@@ -24,9 +28,27 @@ from tribler.core.restapi.rest_endpoint import (
     return_handled_exception,
 )
 
+if TYPE_CHECKING:
+    from aiohttp.abc import Request
+
+    from tribler.core.database.store import MetadataStore
+    from tribler.core.tunnel.community import TriblerTunnelCommunity
+
 TOTAL = "total"
 LOADED = "loaded"
 ALL_LOADED = "all_loaded"
+
+
+class JSONFilesInfo(TypedDict):
+    """
+    A JSON dict to describe file info.
+    """
+
+    index: int
+    name: str
+    size: int
+    included: bool
+    progress: float
 
 
 class DownloadsEndpoint(RESTEndpoint):
@@ -34,35 +56,40 @@ class DownloadsEndpoint(RESTEndpoint):
     This endpoint is responsible for all requests regarding downloads. Examples include getting all downloads,
     starting, pausing and stopping downloads.
     """
-    path = '/downloads'
 
-    def __init__(self, download_manager: DownloadManager, metadata_store=None, tunnel_community=None):
+    path = "/downloads"
+
+    def __init__(self, download_manager: DownloadManager, metadata_store: MetadataStore | None = None,
+                 tunnel_community: TriblerTunnelCommunity | None = None) -> None:
+        """
+        Create a new endpoint to query the status of downloads.
+        """
         super().__init__()
         self.download_manager = download_manager
         self.mds = metadata_store
         self.tunnel_community = tunnel_community
         self.app.add_routes([
-            web.get('', self.get_downloads),
-            web.put('', self.add_download),
-            web.delete('/{infohash}', self.delete_download),
-            web.patch('/{infohash}', self.update_download),
-            web.get('/{infohash}/torrent', self.get_torrent),
-            web.get('/{infohash}/files', self.get_files),
-            web.get('/{infohash}/files/expand', self.expand_tree_directory),
-            web.get('/{infohash}/files/collapse', self.collapse_tree_directory),
-            web.get('/{infohash}/files/select', self.select_tree_path),
-            web.get('/{infohash}/files/deselect', self.deselect_tree_path),
-            web.get('/{infohash}/stream/{fileindex}', self.stream, allow_head=False)
+            web.get("", self.get_downloads),
+            web.put("", self.add_download),
+            web.delete("/{infohash}", self.delete_download),
+            web.patch("/{infohash}", self.update_download),
+            web.get("/{infohash}/torrent", self.get_torrent),
+            web.get("/{infohash}/files", self.get_files),
+            web.get("/{infohash}/files/expand", self.expand_tree_directory),
+            web.get("/{infohash}/files/collapse", self.collapse_tree_directory),
+            web.get("/{infohash}/files/select", self.select_tree_path),
+            web.get("/{infohash}/files/deselect", self.deselect_tree_path),
+            web.get("/{infohash}/stream/{fileindex}", self.stream, allow_head=False)
         ])
 
     @staticmethod
-    def return_404(request, message="this download does not exist"):
+    def return_404(request: Request, message: str = "this download does not exist") -> RESTResponse:
         """
         Returns a 404 response code if your channel has not been created.
         """
         return RESTResponse({"error": message}, status=HTTP_NOT_FOUND)
 
-    def create_dconfig_from_params(self, parameters):
+    def create_dconfig_from_params(self, parameters: dict) -> tuple[DownloadConfig, None] | tuple[None, str]:
         """
         Create a download configuration based on some given parameters.
 
@@ -94,15 +121,14 @@ class DownloadsEndpoint(RESTEndpoint):
         return download_config, None
 
     @staticmethod
-    def get_files_info_json(download):
+    def get_files_info_json(download: Download) -> list[JSONFilesInfo]:
         """
         Return file information as JSON from a specified download.
         """
         files_json = []
-        files_completion = {name: progress for name, progress in download.get_state().get_files_completion()}
+        files_completion = dict(download.get_state().get_files_completion())
         selected_files = download.config.get_selected_files()
-        file_index = 0
-        for fn, size in download.get_def().get_files_with_length():
+        for file_index, (fn, size) in enumerate(download.get_def().get_files_with_length()):
             files_json.append({
                 "index": file_index,
                 # We always return files in Posix format to make GUI independent of Core and simplify testing
@@ -111,11 +137,10 @@ class DownloadsEndpoint(RESTEndpoint):
                 "included": (file_index in selected_files or not selected_files),
                 "progress": files_completion.get(fn, 0.0)
             })
-            file_index += 1
         return files_json
 
     @staticmethod
-    def get_files_info_json_paged(download: Download, view_start: Path, view_size: int):
+    def get_files_info_json_paged(download: Download, view_start: Path, view_size: int) -> list[JSONFilesInfo]:
         """
         Return file info, similar to get_files_info_json() but paged (based on view_start and view_size).
 
@@ -130,7 +155,7 @@ class DownloadsEndpoint(RESTEndpoint):
                 "index": IllegalFileIndex.unloaded.value,
                 "name": "loading...",
                 "size": 0,
-                "included": 0,
+                "included": False,
                 "progress": 0.0
             }]
         return [
@@ -149,77 +174,77 @@ class DownloadsEndpoint(RESTEndpoint):
         tags=["Libtorrent"],
         summary="Return all downloads, both active and inactive",
         parameters=[{
-            'in': 'query',
-            'name': 'get_peers',
-            'description': 'Flag indicating whether or not to include peers',
-            'type': 'boolean',
-            'required': False
+            "in": "query",
+            "name": "get_peers",
+            "description": "Flag indicating whether or not to include peers",
+            "type": "boolean",
+            "required": False
         },
             {
-                'in': 'query',
-                'name': 'get_pieces',
-                'description': 'Flag indicating whether or not to include pieces',
-                'type': 'boolean',
-                'required': False
+                "in": "query",
+                "name": "get_pieces",
+                "description": "Flag indicating whether or not to include pieces",
+                "type": "boolean",
+                "required": False
             },
             {
-                'in': 'query',
-                'name': 'get_availability',
-                'description': 'Flag indicating whether or not to include availability',
-                'type': 'boolean',
-                'required': False
+                "in": "query",
+                "name": "get_availability",
+                "description": "Flag indicating whether or not to include availability",
+                "type": "boolean",
+                "required": False
             },
             {
-                'in': 'query',
-                'name': 'infohash',
-                'description': 'Limit fetching of files, peers, and pieces to a specific infohash',
-                'type': 'str',
-                'required': False
+                "in": "query",
+                "name": "infohash",
+                "description": "Limit fetching of files, peers, and pieces to a specific infohash",
+                "type": "str",
+                "required": False
             },
             {
-                'in': 'query',
-                'name': 'excluded',
-                'description': 'If specified, only return downloads excluding this one',
-                'type': 'str',
-                'required': False
+                "in": "query",
+                "name": "excluded",
+                "description": "If specified, only return downloads excluding this one",
+                "type": "str",
+                "required": False
             }
         ],
         responses={
             200: {
                 "schema": schema(DownloadsResponse={
-                    'downloads': schema(Download={
-                        'name': String,
-                        'progress': Float,
-                        'infohash': String,
-                        'speed_down': Float,
-                        'speed_up': Float,
-                        'status': String,
-                        'status_code': Integer,
-                        'size': Integer,
-                        'eta': Integer,
-                        'num_peers': Integer,
-                        'num_seeds': Integer,
-                        'all_time_upload': Integer,
-                        'all_time_download': Integer,
-                        'all_time_ratio': Float,
-                        'files': String,
-                        'trackers': String,
-                        'hops': Integer,
-                        'anon_download': Boolean,
-                        'safe_seeding': Boolean,
-                        'max_upload_speed': Integer,
-                        'max_download_speed': Integer,
-                        'destination': String,
-                        'availability': Float,
-                        'peers': String,
-                        'total_pieces': Integer,
-                        'vod_mode': Boolean,
-                        'vod_prebuffering_progress': Float,
-                        'vod_prebuffering_progress_consec': Float,
-                        'error': String,
-                        'time_added': Integer
+                    "downloads": schema(Download={
+                        "name": String,
+                        "progress": Float,
+                        "infohash": String,
+                        "speed_down": Float,
+                        "speed_up": Float,
+                        "status": String,
+                        "status_code": Integer,
+                        "size": Integer,
+                        "eta": Integer,
+                        "num_peers": Integer,
+                        "num_seeds": Integer,
+                        "all_time_upload": Integer,
+                        "all_time_download": Integer,
+                        "all_time_ratio": Float,
+                        "files": String,
+                        "trackers": String,
+                        "hops": Integer,
+                        "anon_download": Boolean,
+                        "safe_seeding": Boolean,
+                        "max_upload_speed": Integer,
+                        "max_download_speed": Integer,
+                        "destination": String,
+                        "availability": Float,
+                        "peers": String,
+                        "total_pieces": Integer,
+                        "vod_mode": Boolean,
+                        "vod_prebuffering_progress": Float,
+                        "vod_prebuffering_progress_consec": Float,
+                        "error": String,
+                        "time_added": Integer
                     }),
-                    'checkpoints': schema(Checkpoints={
+                    "checkpoints": schema(Checkpoints={
                         TOTAL: Integer,
                         LOADED: Integer,
                         ALL_LOADED: Boolean,
@@ -235,7 +260,10 @@ class DownloadsEndpoint(RESTEndpoint):
                     "get_pieces flag is set. Note that setting this flag has a negative impact on performance "
                     "and should only be used in situations where this data is required. "
     )
-    async def get_downloads(self, request):
+    async def get_downloads(self, request: Request) -> RESTResponse:  # noqa: C901
+        """
+        Return all downloads, both active and inactive.
+        """
         params = request.query
         get_peers = params.get('get_peers', '0') == '1'
         get_pieces = params.get('get_pieces', '0') == '1'
@@ -309,13 +337,13 @@ class DownloadsEndpoint(RESTEndpoint):
 
                 })
 
-            if unfiltered or params.get('infohash') == info["infohash"]:
+            if unfiltered or params.get("infohash") == info["infohash"]:
                 # Add peers information if requested
                 if get_peers:
                     peer_list = state.get_peer_list(include_have=False)
                     for peer_info in peer_list:
-                        if 'extended_version' in peer_info:
-                            peer_info['extended_version'] = self._safe_extended_peer_info(peer_info['extended_version'])
+                        if "extended_version" in peer_info:
+                            peer_info["extended_version"] = self._safe_extended_peer_info(peer_info["extended_version"])
 
                     info["peers"] = peer_list
 
@@ -334,43 +362,46 @@ class DownloadsEndpoint(RESTEndpoint):
         tags=["Libtorrent"],
         summary="Start a download from a provided URI.",
         parameters=[{
-            'in': 'query',
-            'name': 'get_peers',
-            'description': 'Flag indicating whether or not to include peers',
-            'type': 'boolean',
-            'required': False
+            "in": "query",
+            "name": "get_peers",
+            "description": "Flag indicating whether or not to include peers",
+            "type": "boolean",
+            "required": False
         },
             {
-                'in': 'query',
-                'name': 'get_pieces',
-                'description': 'Flag indicating whether or not to include pieces',
-                'type': 'boolean',
-                'required': False
+                "in": "query",
+                "name": "get_pieces",
+                "description": "Flag indicating whether or not to include pieces",
+                "type": "boolean",
+                "required": False
             },
             {
-                'in': 'query',
-                'name': 'get_files',
-                'description': 'Flag indicating whether or not to include files',
-                'type': 'boolean',
-                'required': False
+                "in": "query",
+                "name": "get_files",
+                "description": "Flag indicating whether or not to include files",
+                "type": "boolean",
+                "required": False
             }],
         responses={
             200: {
                 "schema": schema(AddDownloadResponse={"started": Boolean, "infohash": String}),
-                'examples': {"started": True, "infohash": "4344503b7e797ebf31582327a5baae35b11bda01"}
+                "examples": {"started": True, "infohash": "4344503b7e797ebf31582327a5baae35b11bda01"}
             }
         },
     )
     @json_schema(schema(AddDownloadRequest={
-        'anon_hops': (Integer, 'Number of hops for the anonymous download. No hops is equivalent to a plain download'),
-        'safe_seeding': (Boolean, 'Whether the seeding of the download should be anonymous or not'),
-        'destination': (String, 'the download destination path of the torrent'),
-        'uri*': (String, 'The URI of the torrent file that should be downloaded. This URI can either represent a file '
-                         'location, a magnet link or a HTTP(S) url.'),
+        "anon_hops": (Integer, "Number of hops for the anonymous download. No hops is equivalent to a plain download"),
+        "safe_seeding": (Boolean, "Whether the seeding of the download should be anonymous or not"),
+        "destination": (String, "the download destination path of the torrent"),
+        "uri*": (String, "The URI of the torrent file that should be downloaded. This URI can either represent a file "
+                         "location, a magnet link or a HTTP(S) url."),
     }))
-    async def add_download(self, request):
+    async def add_download(self, request: Request) -> RESTResponse:
+        """
+        Start a download from a provided URI.
+        """
         params = await request.json()
-        uri = params.get('uri')
+        uri = params.get("uri")
         if not uri:
             return RESTResponse({"error": "uri parameter missing"}, status=HTTP_BAD_REQUEST)
 
@@ -389,41 +420,48 @@ class DownloadsEndpoint(RESTEndpoint):
         tags=["Libtorrent"],
         summary="Remove a specific download.",
         parameters=[{
-            'in': 'path',
-            'name': 'infohash',
-            'description': 'Infohash of the download to remove',
-            'type': 'string',
-            'required': True
+            "in": "path",
+            "name": "infohash",
+            "description": "Infohash of the download to remove",
+            "type": "string",
+            "required": True
         }],
         responses={
             200: {
                 "schema": schema(DeleteDownloadResponse={"removed": Boolean, "infohash": String}),
-                'examples': {"removed": True, "infohash": "4344503b7e797ebf31582327a5baae35b11bda01"}
+                "examples": {"removed": True, "infohash": "4344503b7e797ebf31582327a5baae35b11bda01"}
             }
         },
     )
     @json_schema(schema(RemoveDownloadRequest={
         'remove_data': (Boolean, 'Whether or not to remove the associated data'),
     }))
-    async def delete_download(self, request):
+    async def delete_download(self, request: Request) -> RESTResponse:
+        """
+        Remove a specific download.
+        """
         parameters = await request.json()
-        if 'remove_data' not in parameters:
+        if "remove_data" not in parameters:
             return RESTResponse({"error": "remove_data parameter missing"}, status=HTTP_BAD_REQUEST)
 
-        infohash = unhexlify(request.match_info['infohash'])
+        infohash = unhexlify(request.match_info["infohash"])
         download = self.download_manager.get_download(infohash)
         if not download:
             return DownloadsEndpoint.return_404(request)
 
         try:
-            await self.download_manager.remove_download(download, remove_content=parameters['remove_data'])
+            await self.download_manager.remove_download(download, remove_content=parameters["remove_data"])
         except Exception as e:
             self._logger.exception(e)
             return return_handled_exception(e)
 
         return RESTResponse({"removed": True, "infohash": hexlify(download.get_def().get_infohash()).decode()})
 
-    async def vod_response(self, download, parameters, request, vod_mode):
+    async def vod_response(self, download: Download, parameters: dict, request: Request,
+                           vod_mode: bool) -> RESTResponse:
+        """
+        Return a response for the VOD status of a download.
+        """
         modified = False
         if vod_mode:
             file_index = parameters.get("fileindex")
@@ -453,27 +491,30 @@ class DownloadsEndpoint(RESTEndpoint):
         tags=["Libtorrent"],
         summary="Update a specific download.",
         parameters=[{
-            'in': 'path',
-            'name': 'infohash',
-            'description': 'Infohash of the download to update',
-            'type': 'string',
-            'required': True
+            "in": "path",
+            "name": "infohash",
+            "description": "Infohash of the download to update",
+            "type": "string",
+            "required": True
         }],
         responses={
             200: {
                 "schema": schema(UpdateDownloadResponse={"modified": Boolean, "infohash": String}),
-                'examples': {"modified": True, "infohash": "4344503b7e797ebf31582327a5baae35b11bda01"}
+                "examples": {"modified": True, "infohash": "4344503b7e797ebf31582327a5baae35b11bda01"}
             }
         },
     )
     @json_schema(schema(UpdateDownloadRequest={
-        'state': (String, 'State parameter to be passed to modify the state of the download (resume/stop/recheck)'),
-        'selected_files': (List(Integer), 'File indexes to be included in the download'),
-        'anon_hops': (Integer, 'The anonymity of a download can be changed at runtime by passing the anon_hops '
-                               'parameter, however, this must be the only parameter in this request.')
+        "state": (String, "State parameter to be passed to modify the state of the download (resume/stop/recheck)"),
+        "selected_files": (List(Integer), "File indexes to be included in the download"),
+        "anon_hops": (Integer, "The anonymity of a download can be changed at runtime by passing the anon_hops "
+                               "parameter, however, this must be the only parameter in this request.")
     }))
-    async def update_download(self, request):
-        infohash = unhexlify(request.match_info['infohash'])
+    async def update_download(self, request: Request) -> RESTResponse:  # noqa: C901, PLR0911, PLR0912
+        """
+        Update a specific download.
+        """
+        infohash = unhexlify(request.match_info["infohash"])
         download = self.download_manager.get_download(infohash)
         if not download:
             return DownloadsEndpoint.return_404(request)
@@ -486,10 +527,10 @@ class DownloadsEndpoint(RESTEndpoint):
                                     status=HTTP_BAD_REQUEST)
             return await self.vod_response(download, parameters, request, vod_mode)
 
-        if len(parameters) > 1 and 'anon_hops' in parameters:
+        if len(parameters) > 1 and "anon_hops" in parameters:
             return RESTResponse({"error": "anon_hops must be the only parameter in this request"},
                                 status=HTTP_BAD_REQUEST)
-        elif 'anon_hops' in parameters:
+        if 'anon_hops' in parameters:
             anon_hops = int(parameters['anon_hops'])
             try:
                 await self.download_manager.update_hops(download, anon_hops)
@@ -498,14 +539,14 @@ class DownloadsEndpoint(RESTEndpoint):
                 return return_handled_exception(e)
             return RESTResponse({"modified": True, "infohash": hexlify(download.get_def().get_infohash()).decode()})
 
-        if 'selected_files' in parameters:
-            selected_files_list = parameters['selected_files']
+        if "selected_files" in parameters:
+            selected_files_list = parameters["selected_files"]
             num_files = len(download.tdef.get_files())
-            if not all([0 <= index < num_files for index in selected_files_list]):
+            if not all(0 <= index < num_files for index in selected_files_list):
                 return RESTResponse({"error": "index out of range"}, status=HTTP_BAD_REQUEST)
             download.set_selected_files(selected_files_list)
 
-        if state := parameters.get('state'):
+        if state := parameters.get("state"):
             if state == "resume":
                 download.resume()
             elif state == "stop":
@@ -513,7 +554,7 @@ class DownloadsEndpoint(RESTEndpoint):
             elif state == "recheck":
                 download.force_recheck()
             elif state == "move_storage":
-                dest_dir = Path(parameters['dest_dir'])
+                dest_dir = Path(parameters["dest_dir"])
                 if not dest_dir.exists():
                     return RESTResponse({"error": f"Target directory ({dest_dir}) does not exist"},
                                         status=HTTP_BAD_REQUEST)
@@ -528,18 +569,21 @@ class DownloadsEndpoint(RESTEndpoint):
         tags=["Libtorrent"],
         summary="Return the .torrent file associated with the specified download.",
         parameters=[{
-            'in': 'path',
-            'name': 'infohash',
-            'description': 'Infohash of the download from which to get the .torrent file',
-            'type': 'string',
-            'required': True
+            "in": "path",
+            "name": "infohash",
+            "description": "Infohash of the download from which to get the .torrent file",
+            "type": "string",
+            "required": True
         }],
         responses={
             200: {'description': 'The torrent'}
         }
     )
-    async def get_torrent(self, request):
-        infohash = unhexlify(request.match_info['infohash'])
+    async def get_torrent(self, request: Request) -> RESTResponse:
+        """
+        Return the .torrent file associated with the specified download.
+        """
+        infohash = unhexlify(request.match_info["infohash"])
         download = self.download_manager.get_download(infohash)
         if not download:
             return DownloadsEndpoint.return_404(request)
@@ -548,61 +592,64 @@ class DownloadsEndpoint(RESTEndpoint):
         if not torrent:
             return DownloadsEndpoint.return_404(request)
 
-        return RESTResponse(lt.bencode(torrent), headers={'content-type': 'application/x-bittorrent',
-                                                          'Content-Disposition': 'attachment; filename=%s.torrent'
+        return RESTResponse(lt.bencode(torrent), headers={"content-type": "application/x-bittorrent",
+                                                          "Content-Disposition": "attachment; filename=%s.torrent"
                                                                                  % hexlify(infohash)})
 
     @docs(
         tags=["Libtorrent"],
         summary="Return file information of a specific download.",
         parameters=[{
-            'in': 'path',
-            'name': 'infohash',
-            'description': 'Infohash of the download to from which to get file information',
-            'type': 'string',
-            'required': True
+            "in": "path",
+            "name": "infohash",
+            "description": "Infohash of the download to from which to get file information",
+            "type": "string",
+            "required": True
         },
             {
-                'in': 'query',
-                'name': 'view_start_path',
-                'description': 'Path of the file or directory to form a view for',
-                'type': 'string',
-                'required': False
+                "in": "query",
+                "name": "view_start_path",
+                "description": "Path of the file or directory to form a view for",
+                "type": "string",
+                "required": False
             },
             {
-                'in': 'query',
-                'name': 'view_size',
-                'description': 'Number of files to include in the view',
-                'type': 'number',
-                'required': False
+                "in": "query",
+                "name": "view_size",
+                "description": "Number of files to include in the view",
+                "type": "number",
+                "required": False
             }],
         responses={
             200: {
-                "schema": schema(GetFilesResponse={"files": [schema(File={'index': Integer,
-                                                                          'name': String,
-                                                                          'size': Integer,
-                                                                          'included': Boolean,
-                                                                          'progress': Float})]})
+                "schema": schema(GetFilesResponse={"files": [schema(File={"index": Integer,
+                                                                          "name": String,
+                                                                          "size": Integer,
+                                                                          "included": Boolean,
+                                                                          "progress": Float})]})
             }
         }
     )
-    async def get_files(self, request):
-        infohash = unhexlify(request.match_info['infohash'])
+    async def get_files(self, request: Request) -> RESTResponse:
+        """
+        Return file information of a specific download.
+        """
+        infohash = unhexlify(request.match_info["infohash"])
         download = self.download_manager.get_download(infohash)
         if not download:
             return DownloadsEndpoint.return_404(request)
 
         params = request.query
-        view_start_path = params.get('view_start_path')
+        view_start_path = params.get("view_start_path")
         if view_start_path is None:
             return RESTResponse({
-                "infohash": request.match_info['infohash'],
+                "infohash": request.match_info["infohash"],
                 "files": self.get_files_info_json(download)
             })
 
-        view_size = int(params.get('view_size', '100'))
+        view_size = int(params.get("view_size", "100"))
         return RESTResponse({
-            "infohash": request.match_info['infohash'],
+            "infohash": request.match_info["infohash"],
             "query": view_start_path,
             "files": self.get_files_info_json_paged(download, Path(view_start_path), view_size)
         })
@@ -611,101 +658,110 @@ class DownloadsEndpoint(RESTEndpoint):
         tags=["Libtorrent"],
         summary="Collapse a tree directory.",
         parameters=[{
-            'in': 'path',
-            'name': 'infohash',
-            'description': 'Infohash of the download',
-            'type': 'string',
-            'required': True
+            "in": "path",
+            "name": "infohash",
+            "description": "Infohash of the download",
+            "type": "string",
+            "required": True
         },
             {
-                'in': 'query',
-                'name': 'path',
-                'description': 'Path of the directory to collapse',
-                'type': 'string',
-                'required': True
+                "in": "query",
+                "name": "path",
+                "description": "Path of the directory to collapse",
+                "type": "string",
+                "required": True
             }],
         responses={
             200: {
-                "schema": schema(File={'path': path})
+                "schema": schema(File={"path": path})
             }
         }
     )
-    async def collapse_tree_directory(self, request):
-        infohash = unhexlify(request.match_info['infohash'])
+    async def collapse_tree_directory(self, request: Request) -> RESTResponse:
+        """
+        Collapse a tree directory.
+        """
+        infohash = unhexlify(request.match_info["infohash"])
         download = self.download_manager.get_download(infohash)
         if not download:
             return DownloadsEndpoint.return_404(request)
 
         params = request.query
-        path = params.get('path')
+        path = params.get("path")
         download.tdef.torrent_file_tree.collapse(Path(path))
 
-        return RESTResponse({'path': path})
+        return RESTResponse({"path": path})
 
     @docs(
         tags=["Libtorrent"],
         summary="Expand a tree directory.",
         parameters=[{
-            'in': 'path',
-            'name': 'infohash',
-            'description': 'Infohash of the download',
-            'type': 'string',
-            'required': True
+            "in": "path",
+            "name": "infohash",
+            "description": "Infohash of the download",
+            "type": "string",
+            "required": True
         },
             {
-                'in': 'query',
-                'name': 'path',
-                'description': 'Path of the directory to expand',
-                'type': 'string',
-                'required': True
+                "in": "query",
+                "name": "path",
+                "description": "Path of the directory to expand",
+                "type": "string",
+                "required": True
             }],
         responses={
             200: {
-                "schema": schema(File={'path': String})
+                "schema": schema(File={"path": String})
             }
         }
     )
-    async def expand_tree_directory(self, request):
-        infohash = unhexlify(request.match_info['infohash'])
+    async def expand_tree_directory(self, request: Request) -> RESTResponse:
+        """
+        Expand a tree directory.
+        """
+        infohash = unhexlify(request.match_info["infohash"])
         download = self.download_manager.get_download(infohash)
         if not download:
             return DownloadsEndpoint.return_404(request)
 
         params = request.query
-        path = params.get('path')
+        path = params.get("path")
         download.tdef.torrent_file_tree.expand(Path(path))
 
-        return RESTResponse({'path': path})
+        return RESTResponse({"path": path})
 
     @docs(
         tags=["Libtorrent"],
         summary="Select a tree path.",
         parameters=[{
-            'in': 'path',
-            'name': 'infohash',
-            'description': 'Infohash of the download',
-            'type': 'string',
-            'required': True
+            "in": "path",
+            "name": "infohash",
+            "description": "Infohash of the download",
+            "type": "string",
+            "required": True
         },
             {
-                'in': 'query',
-                'name': 'path',
-                'description': 'Path of the directory to select',
-                'type': 'string',
-                'required': True
+                "in": "query",
+                "name": "path",
+                "description": "Path of the directory to select",
+                "type": "string",
+                "required": True
             }],
         responses={
             200: {}
         }
     )
-    async def select_tree_path(self, request):
-        infohash = unhexlify(request.match_info['infohash'])
+    async def select_tree_path(self, request: Request) -> RESTResponse:
+        """
+        Select a tree path.
+        """
+        infohash = unhexlify(request.match_info["infohash"])
         download = self.download_manager.get_download(infohash)
         if not download:
             return DownloadsEndpoint.return_404(request)
 
         params = request.query
-        path = params.get('path')
+        path = params.get("path")
         download.set_selected_file_or_dir(Path(path), True)
 
         return RESTResponse({})
@@ -714,31 +770,34 @@ class DownloadsEndpoint(RESTEndpoint):
         tags=["Libtorrent"],
         summary="Deselect a tree path.",
         parameters=[{
-            'in': 'path',
-            'name': 'infohash',
-            'description': 'Infohash of the download',
-            'type': 'string',
-            'required': True
+            "in": "path",
+            "name": "infohash",
+            "description": "Infohash of the download",
+            "type": "string",
+            "required": True
         },
             {
-                'in': 'query',
-                'name': 'path',
-                'description': 'Path of the directory to deselect',
-                'type': 'string',
-                'required': True
+                "in": "query",
+                "name": "path",
+                "description": "Path of the directory to deselect",
+                "type": "string",
+                "required": True
             }],
         responses={
             200: {}
         }
     )
-    async def deselect_tree_path(self, request):
-        infohash = unhexlify(request.match_info['infohash'])
+    async def deselect_tree_path(self, request: Request) -> RESTResponse:
+        """
+        Deselect a tree path.
+        """
+        infohash = unhexlify(request.match_info["infohash"])
         download = self.download_manager.get_download(infohash)
         if not download:
             return DownloadsEndpoint.return_404(request)
 
         params = request.query
-        path = params.get('path')
+        path = params.get("path")
         download.set_selected_file_or_dir(Path(path), False)
 
         return RESTResponse({})
@@ -765,9 +824,10 @@ class DownloadsEndpoint(RESTEndpoint):
 
         return status
 
-    def _safe_extended_peer_info(self, ext_peer_info):
+    def _safe_extended_peer_info(self, ext_peer_info: bytes) -> str:
         """
         Given a string describing peer info, return a json.dumps() safe representation.
+
         :param ext_peer_info: the string to convert to a dumpable format
         :return: the safe string
         """
@@ -779,37 +839,41 @@ class DownloadsEndpoint(RESTEndpoint):
             return ext_peer_info.decode()
         except UnicodeDecodeError as e:
             # We might have some special unicode characters in here
-            self._logger.warning(f"Error while decoding peer info: {ext_peer_info}. {e.__class__.__name__}: {e}")
+            self._logger.warning("Error while decoding peer info: %s. %s: %s",
+                                 str(ext_peer_info), e.__class__.__name__, str(e))
             return ''.join(map(chr, ext_peer_info))
 
     @docs(
         tags=["Libtorrent"],
         summary="Stream the contents of a file that is being downloaded.",
         parameters=[{
-            'in': 'path',
-            'name': 'infohash',
-            'description': 'Infohash of the download to stream',
-            'type': 'string',
-            'required': True
+            "in": "path",
+            "name": "infohash",
+            "description": "Infohash of the download to stream",
+            "type": "string",
+            "required": True
         },
             {
-                'in': 'path',
-                'name': 'fileindex',
-                'description': 'The fileindex to stream',
-                'type': 'string',
-                'required': True
+                "in": "path",
+                "name": "fileindex",
+                "description": "The fileindex to stream",
+                "type": "string",
+                "required": True
             }],
         responses={
-            206: {'description': 'Contents of the stream'}
+            206: {"description": "Contents of the stream"}
         }
     )
-    async def stream(self, request):
-        infohash = unhexlify(request.match_info['infohash'])
+    async def stream(self, request: Request) -> web.StreamResponse:  # noqa: C901
+        """
+        Stream the contents of a file that is being downloaded.
+        """
+        infohash = unhexlify(request.match_info["infohash"])
         download = self.download_manager.get_download(infohash)
         if not download:
             return DownloadsEndpoint.return_404(request)
 
-        file_index = int(request.match_info['fileindex'])
+        file_index = int(request.match_info["fileindex"])
 
         http_range = request.http_range
         start = http_range.start or 0
@@ -821,21 +885,21 @@ class DownloadsEndpoint(RESTEndpoint):
         stop = download.stream.filesize if http_range.stop is None else min(http_range.stop, download.stream.filesize)
 
         if not start < stop or not 0 <= start < download.stream.filesize or not 0 < stop <= download.stream.filesize:
-            return RESTResponse('Requested Range Not Satisfiable', status=416)
+            return RESTResponse("Requested Range Not Satisfiable", status=416)
 
         response = web.StreamResponse(status=206,
-                                      reason='OK',
-                                      headers={'Accept-Ranges': 'bytes',
-                                               'Content-Type': 'application/octet-stream',
-                                               'Content-Length': f'{stop - start}',
-                                               'Content-Range': f'{start}-{stop}/{download.stream.filesize}'})
+                                      reason="OK",
+                                      headers={"Accept-Ranges": "bytes",
+                                               "Content-Type": "application/octet-stream",
+                                               "Content-Length": f"{stop - start}",
+                                               "Content-Range": f"{start}-{stop}/{download.stream.filesize}"})
         response.force_close()
         with suppress(CancelledError, ConnectionResetError):
             async with StreamChunk(download.stream, start) as chunk:
                 await response.prepare(request)
                 bytes_todo = stop - start
                 bytes_done = 0
-                self._logger.info('Got range request for %s-%s (%s bytes)', start, stop, bytes_todo)
+                self._logger.info("Got range request for %s-%s (%s bytes)", start, stop, bytes_todo)
                 while not request.transport.is_closing():
                     if chunk.seekpos >= download.stream.filesize:
                         break

--- a/src/tribler/core/libtorrent/restapi/libtorrent_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/libtorrent_endpoint.py
@@ -2,6 +2,7 @@ from asyncio import Future
 from binascii import hexlify
 
 from aiohttp import web
+from aiohttp.abc import Request
 from aiohttp_apispec import docs
 from ipv8.REST.schema import schema
 from marshmallow.fields import Integer
@@ -14,85 +15,95 @@ class LibTorrentEndpoint(RESTEndpoint):
     """
     Endpoint for getting information about libtorrent sessions and settings.
     """
-    path = '/libtorrent'
 
-    def __init__(self, download_manager: DownloadManager):
+    path = "/libtorrent"
+
+    def __init__(self, download_manager: DownloadManager) -> None:
+        """
+        Create a new libtorrent endpoint.
+        """
         super().__init__()
         self.download_manager = download_manager
-        self.app.add_routes([web.get('/settings', self.get_libtorrent_settings),
-                             web.get('/session', self.get_libtorrent_session_info)])
+        self.app.add_routes([web.get("/settings", self.get_libtorrent_settings),
+                             web.get("/session", self.get_libtorrent_session_info)])
 
     @docs(
         tags=["Libtorrent"],
         summary="Return Libtorrent session settings.",
         parameters=[{
-            'in': 'query',
-            'name': 'hop',
-            'description': 'The hop count of the session for which to return settings',
-            'type': 'string',
-            'required': False
+            "in": "query",
+            "name": "hop",
+            "description": "The hop count of the session for which to return settings",
+            "type": "string",
+            "required": False
         }],
         responses={
             200: {
-                'description': 'Return a dictonary with key-value pairs from the Libtorrent session settings',
-                "schema": schema(LibtorrentSessionResponse={'hop': Integer,
-                                                            'settings': schema(LibtorrentSettings={})})
+                "description": "Return a dictonary with key-value pairs from the Libtorrent session settings",
+                "schema": schema(LibtorrentSessionResponse={"hop": Integer,
+                                                            "settings": schema(LibtorrentSettings={})})
             }
         }
     )
-    async def get_libtorrent_settings(self, request):
+    async def get_libtorrent_settings(self, request: Request) -> RESTResponse:
+        """
+        Return Libtorrent session settings.
+        """
         args = request.query
         hop = 0
-        if 'hop' in args and args['hop']:
-            hop = int(args['hop'])
+        if args.get("hop"):
+            hop = int(args["hop"])
 
         if hop not in self.download_manager.ltsessions:
-            return RESTResponse({'hop': hop, "settings": {}})
+            return RESTResponse({"hop": hop, "settings": {}})
 
         lt_session = self.download_manager.ltsessions[hop]
         if hop == 0:
             lt_settings = self.download_manager.get_session_settings(lt_session)
-            lt_settings['peer_fingerprint'] = hexlify(lt_settings['peer_fingerprint'].encode()).decode()
+            lt_settings["peer_fingerprint"] = hexlify(lt_settings["peer_fingerprint"].encode()).decode()
         else:
             lt_settings = lt_session.get_settings()
 
-        return RESTResponse({'hop': hop, "settings": lt_settings})
+        return RESTResponse({"hop": hop, "settings": lt_settings})
 
     @docs(
         tags=["Libtorrent"],
         summary="Return Libtorrent session information.",
         parameters=[{
-            'in': 'query',
-            'name': 'hop',
-            'description': 'The hop count of the session for which to return information',
-            'type': 'string',
-            'required': False
+            "in": "query",
+            "name": "hop",
+            "description": "The hop count of the session for which to return information",
+            "type": "string",
+            "required": False
         }],
         responses={
             200: {
-                'description': 'Return a dictonary with key-value pairs from the Libtorrent session information',
-                "schema": schema(LibtorrentinfoResponse={'hop': Integer,
-                                                         'settings': schema(LibtorrentInfo={})})
+                "description": "Return a dictonary with key-value pairs from the Libtorrent session information",
+                "schema": schema(LibtorrentinfoResponse={"hop": Integer,
+                                                         "settings": schema(LibtorrentInfo={})})
             }
         }
     )
-    async def get_libtorrent_session_info(self, request):
+    async def get_libtorrent_session_info(self, request: Request) -> RESTResponse:
+        """
+        Return Libtorrent session information.
+        """
         session_stats = Future()
 
-        def on_session_stats_alert_received(alert):
+        def on_session_stats_alert_received(alert) -> None:
             if not session_stats.done():
                 session_stats.set_result(alert.values)
 
         args = request.query
         hop = 0
-        if 'hop' in args and args['hop']:
-            hop = int(args['hop'])
+        if args.get("hop"):
+            hop = int(args["hop"])
 
         if hop not in self.download_manager.ltsessions or \
                 not hasattr(self.download_manager.ltsessions[hop], "post_session_stats"):
-            return RESTResponse({'hop': hop, 'session': {}})
+            return RESTResponse({"hop": hop, "session": {}})
 
         self.download_manager.session_stats_callback = on_session_stats_alert_received
         self.download_manager.ltsessions[hop].post_session_stats()
         stats = await session_stats
-        return RESTResponse({'hop': hop, 'session': stats})
+        return RESTResponse({"hop": hop, "session": stats})

--- a/src/tribler/core/libtorrent/uris.py
+++ b/src/tribler/core/libtorrent/uris.py
@@ -14,17 +14,19 @@ def url_to_path(file_url: str) -> str:
     Convert a URL to a path.
 
     Example:
+    -------
         'file:///path/to/file' -> '/path/to/file'
+
     """
     url = URL(file_url)
 
-    if os.name == 'nt' and url.host:
+    if os.name == "nt" and url.host:
         # UNC file path, \\server\share\path...
         # ref: https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats
         _, share, *segments = url.parts
-        path = (rf'\\{url.host}\{share}', *segments)
-    elif os.name == 'nt':
-        path = (url.path.lstrip('/'), )
+        path = (rf"\\{url.host}\{share}", *segments)
+    elif os.name == "nt":
+        path = (url.path.lstrip("/"), )
     else:
         path = (url.path, )
 
@@ -42,7 +44,7 @@ async def unshorten(uri: str) -> str:
     if scheme not in ("http", "https"):
         return uri
 
-    logger.info(f'Unshortening URI: {uri}')
+    logger.info("Unshortening URI: %s", uri)
 
     async with ClientSession() as session:
         try:
@@ -50,7 +52,7 @@ async def unshorten(uri: str) -> str:
                 if response.status in (301, 302, 303, 307, 308):
                     uri = response.headers.get(LOCATION, uri)
         except Exception as e:
-            logger.warning(f'Error while unshortening a URI: {e.__class__.__name__}: {e}', exc_info=e)
+            logger.warning("Error while unshortening a URI: %s: %s", e.__class__.__name__, str(e), exc_info=e)
 
-    logger.info(f'Unshorted URI: {uri}')
+    logger.info("Unshorted URI: %s", uri)
     return uri

--- a/src/tribler/test_unit/core/libtorrent/download_manager/test_download.py
+++ b/src/tribler/test_unit/core/libtorrent/download_manager/test_download.py
@@ -688,8 +688,8 @@ class TestDownload(TestBase):
 
         result = download.get_tracker_status()
 
-        self.assertEqual([42, "Disabled"], result["[DHT]"])
-        self.assertEqual([7, "Working"], result["[PeX]"])
+        self.assertEqual((42, "Disabled"), result["[DHT]"])
+        self.assertEqual((7, "Working"), result["[PeX]"])
 
     def test_get_tracker_status_get_peer_info_error(self) -> None:
         """
@@ -703,8 +703,8 @@ class TestDownload(TestBase):
 
         result = download.get_tracker_status()
 
-        self.assertEqual([0, "Working"], result["[DHT]"])
-        self.assertEqual([0, "Working"], result["[PeX]"])
+        self.assertEqual((0, "Working"), result["[DHT]"])
+        self.assertEqual((0, "Working"), result["[PeX]"])
 
     async def test_shutdown(self) -> None:
         """

--- a/src/tribler/test_unit/core/libtorrent/download_manager/test_download_manager.py
+++ b/src/tribler/test_unit/core/libtorrent/download_manager/test_download_manager.py
@@ -479,7 +479,7 @@ class TestDownloadManager(TestBase):
         self.manager.ltsessions[0].get_settings = Mock(return_value=settings)
         self.manager.ltsessions[0].download_rate_limit = functools.partial(settings.get, "download_rate_limit")
 
-        self.manager.set_download_rate_limit(42, 0)
+        self.manager.set_download_rate_limit(42)
 
         self.assertEqual(42, self.manager.get_download_rate_limit())
 
@@ -491,6 +491,6 @@ class TestDownloadManager(TestBase):
         self.manager.ltsessions[0].get_settings = Mock(return_value=settings)
         self.manager.ltsessions[0].upload_rate_limit = functools.partial(settings.get, "upload_rate_limit")
 
-        self.manager.set_upload_rate_limit(42, 0)
+        self.manager.set_upload_rate_limit(42)
 
         self.assertEqual(42, self.manager.get_upload_rate_limit())


### PR DESCRIPTION
Fixes #23

This PR:

 - Fixes most of the ruff linting errors in the `src/tribler/core/libtorrent` directory.

Notes:
 - Some violations remain. However, I would like to have a type-checker active before touching those.
 - Types _may_ still be incorrect (see previous point).
 - Some violations are ignored (`noqa: ...`) because I consider them O.K. for now but we can look at our ignores in the future.

