### PR TITLE
Fixed Fake DHT check not being run and notify metadata

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -540,6 +540,13 @@ class DownloadManager(TaskManager):
 
         logger.info("Successfully retrieved metainfo for %s", infohash_hex)
         self.metainfo_cache[infohash] = {"time": timemod.time(), "meta_info": metainfo}
+        self.notifier.notify(Notification.torrent_metadata_added, metadata={
+            "infohash": infohash,
+            "size": download.tdef.get_length(),
+            "title": download.tdef.get_name_utf8(),
+            "metadata_type": 300,
+            "tracker_info": (list(download.tdef.get_trackers()) or [""])[0]
+        })
 
         if infohash in self.metainfo_requests:
             self.metainfo_requests[infohash][1] -= 1

--- a/src/tribler/core/torrent_checker/torrent_checker.py
+++ b/src/tribler/core/torrent_checker/torrent_checker.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from tribler.tribler_config import TriblerConfigManager
 
 TRACKER_SELECTION_INTERVAL = 1  # The interval for querying a random tracker
-TORRENT_SELECTION_INTERVAL = 120  # The interval for checking the health of a random torrent
+TORRENT_SELECTION_INTERVAL = 10  # The interval for checking the health of a random torrent
 MIN_TORRENT_CHECK_INTERVAL = 900  # How much time we should wait before checking a torrent again
 TORRENT_CHECK_RETRY_INTERVAL = 30  # Interval when the torrent was successfully checked for the last time
 MAX_TORRENTS_CHECKED_PER_SESSION = 50
@@ -345,6 +345,7 @@ class TorrentChecker(TaskManager):
         session.add_infohash(infohash)
         self._logger.info("DHT session has been created for %s: %s", infohash_hex, str(session))
         self.sessions["DHT"].append(session)
+        self.register_anonymous_task("FakeDHT resolve", session.connect_to_tracker)
 
         self._logger.info("%d responses for %s have been received: %s", len(responses), infohash_hex, str(responses))
         successful_responses = [response for response in responses if not isinstance(response, Exception)]

--- a/src/tribler/core/torrent_checker/torrentchecker_session.py
+++ b/src/tribler/core/torrent_checker/torrentchecker_session.py
@@ -420,6 +420,8 @@ class FakeDHTSession(TrackerSession):
         now = int(time.time())
         for infohash in self.infohash_list:
             metainfo = await self.download_manager.get_metainfo(infohash, timeout=self.timeout)
+            if metainfo is None:
+                continue
             health = HealthInfo(infohash, seeders=metainfo[b'seeders'], leechers=metainfo[b'leechers'],
                                 last_check=now, self_checked=True)
             health_list.append(health)

--- a/src/tribler/test_unit/core/torrent_checker/test_torrent_checker.py
+++ b/src/tribler/test_unit/core/torrent_checker/test_torrent_checker.py
@@ -5,7 +5,7 @@ import secrets
 import time
 from binascii import unhexlify
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from ipv8.test.base import TestBase
 from ipv8.util import succeed
@@ -66,9 +66,9 @@ class TestTorrentChecker(TestBase):
         self.metadata_store.TorrentMetadata.__class__.instances = []
 
         self.tracker_manager = TrackerManager(state_dir=Path("."), metadata_store=self.metadata_store)
-        self.torrent_checker = TorrentChecker(config=TriblerConfigManager(), download_manager=MagicMock(),
-                                              notifier=MagicMock(), metadata_store=self.metadata_store,
-                                              tracker_manager=self.tracker_manager)
+        self.torrent_checker = TorrentChecker(config=TriblerConfigManager(), tracker_manager=self.tracker_manager,
+                                              download_manager=MagicMock(get_metainfo=AsyncMock()),
+                                              notifier=MagicMock(), metadata_store=self.metadata_store)
 
     async def tearDown(self) -> None:
         """


### PR DESCRIPTION
Fixes #30

This PR:

 - Adds a notification when metadata is resolved to produce a FFA metadata entry "for free".
 - Fixes Fake DHT sessions not actually running.
 - Updates local torrent checking to occur once every 10 seconds instead of once every two minutes.
