### PR TITLE
Various fixes

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -42,7 +42,7 @@ jobs:
           path: libsodium.dll
           key: cache_libsodium_dll
   macos:
-    runs-on: macos-latest
+    runs-on: macos-12
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@v4

--- a/src/run_tribler.py
+++ b/src/run_tribler.py
@@ -51,7 +51,7 @@ def main() -> None:
     asyncio.set_event_loop(asyncio.SelectorEventLoop())
 
     parsed_args = parse_args()
-    logging.basicConfig(level=getattr(logging, parsed_args["log_level"]), stream=sys.stdout)
+    logging.basicConfig(level=parsed_args["log_level"], stream=sys.stdout)
     logger.info("Run Tribler: %s", parsed_args)
 
     root_state_dir = get_root_state_directory(os.environ.get('TSTATEDIR', 'state_directory'))

--- a/src/tribler/core/components.py
+++ b/src/tribler/core/components.py
@@ -131,7 +131,7 @@ class KnowledgeComponent(CommunityLauncher):
 @after("DatabaseComponent")
 @precondition('session.config.get("rendezvous/enabled")')
 @overlay("tribler.core.rendezvous.community", "RendezvousCommunity")
-class RendezvousComponent(CommunityLauncher):
+class RendezvousComponent(BaseLauncher):
 
     def get_kwargs(self, session: object) -> dict:
         from tribler.core.rendezvous.database import RendezvousDatabase

--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -354,8 +354,10 @@ class DownloadManager(TaskManager):
         settings["proxy_hostnames"] = True
         settings["proxy_peer_connections"] = True
         if server is not None:
-            settings["proxy_hostname"] = server[0]
-            settings["proxy_port"] = int(server[1])
+            proxy_host = server[0]
+            if proxy_host:
+                settings["proxy_hostname"] = proxy_host
+                settings["proxy_port"] = int(server[1]) if server[1] else 0
         if auth is not None:
             settings["proxy_username"] = auth[0]
             settings["proxy_password"] = auth[1]


### PR DESCRIPTION
Fixes #34
Fixes #35

This PR:

 - Fixes the log level command line argument not forwarding.
 - Fixes the `RendezvousComponent` inheriting from the wrong base class.
 - Fixes the `proxy_port` config setting not parsing from an empty tuple value.
 - Fixes the GitHub Actions runner using a MacOS version not supported by libtorrent.

