### PR TITLE
Removed TorrentDef and DLManager torrent create methods

### DIFF
--- a/src/tribler/core/libtorrent/download_manager/download_config.py
+++ b/src/tribler/core/libtorrent/download_manager/download_config.py
@@ -144,8 +144,9 @@ class DownloadConfig:
         """
         Write the contents of this config to a file.
         """
-        self.config["filename"] = str(filename)
-        self.config.write()
+        config_obj = cast(ConfigObj, self.config)
+        config_obj.filename = str(filename)
+        config_obj.write()
 
     def set_dest_dir(self, path: Path | str) -> None:
         """

--- a/src/tribler/core/libtorrent/download_manager/download_manager.py
+++ b/src/tribler/core/libtorrent/download_manager/download_manager.py
@@ -25,7 +25,6 @@ from ipv8.taskmanager import TaskManager
 from validate import Validator
 from yarl import URL
 
-from tribler.core.libtorrent import torrents
 from tribler.core.libtorrent.download_manager.download import Download
 from tribler.core.libtorrent.download_manager.download_config import DownloadConfig
 from tribler.core.libtorrent.download_manager.download_state import DownloadState, DownloadStatus
@@ -35,7 +34,6 @@ from tribler.core.notifier import Notification, Notifier
 
 if TYPE_CHECKING:
     from tribler.core.libtorrent.download_manager.dht_health_manager import DHTHealthManager
-    from tribler.core.libtorrent.torrents import TorrentFileResult
     from tribler.tribler_config import TriblerConfigManager
 
 SOCKS5_PROXY_DEF = 2
@@ -1060,17 +1058,6 @@ class DownloadManager(TaskManager):
         Returns the directory in which to checkpoint the Downloads in this Session.
         """
         return self.state_dir / "dlcheckpoints"
-
-    @staticmethod
-    async def create_torrent_file(file_path_list: list[str], params: dict | None = None) -> TorrentFileResult:
-        """
-        Creates a torrent file.
-
-        :param file_path_list: files to add in torrent file
-        :param params: optional parameters for torrent file
-        """
-        return await asyncio.get_event_loop().run_in_executor(None, torrents.create_torrent_file,
-                                                              file_path_list, params or {})
 
     def get_downloads_by_name(self, torrent_name: str) -> list[Download]:
         """

--- a/src/tribler/test_integration/test_hidden_services.py
+++ b/src/tribler/test_integration/test_hidden_services.py
@@ -4,6 +4,7 @@ from asyncio import sleep
 from typing import TYPE_CHECKING, cast
 from unittest.mock import Mock
 
+import libtorrent
 from ipv8.community import CommunitySettings
 from ipv8.keyvault.crypto import default_eccrypto
 from ipv8.messaging.anonymization.tunnel import PEER_FLAG_EXIT_BT
@@ -17,6 +18,7 @@ from tribler.core.libtorrent.download_manager.download_config import DownloadCon
 from tribler.core.libtorrent.download_manager.download_manager import DownloadManager
 from tribler.core.libtorrent.download_manager.download_state import DownloadStatus
 from tribler.core.libtorrent.torrentdef import TorrentDef, TorrentDefNoMetainfo
+from tribler.core.libtorrent.torrents import create_torrent_file
 from tribler.core.notifier import Notifier
 from tribler.core.socks5.server import Socks5Server
 from tribler.core.tunnel.community import TriblerTunnelCommunity, TriblerTunnelSettings
@@ -207,9 +209,8 @@ class TestHiddenServicesDownload(TestBase[TriblerTunnelCommunity]):
         with open(config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso", "wb") as f:  # noqa: ASYNC101
             f.write(bytes([0] * 524288))
 
-        tdef = TorrentDef()
-        tdef.add_content(config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso")
-        tdef.save()
+        metainfo = create_torrent_file([config.get_dest_dir() / "ubuntu-15.04-desktop-amd64.iso"], {})["metainfo"]
+        tdef = TorrentDef(metainfo=libtorrent.bdecode(metainfo))
 
         download = await self.download_manager_seeder.start_download(tdef=tdef, config=config)
         await download.wait_for_status(DownloadStatus.SEEDING)

--- a/src/tribler/test_unit/core/libtorrent/restapi/test_create_torrent_endpoint.py
+++ b/src/tribler/test_unit/core/libtorrent/restapi/test_create_torrent_endpoint.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 from configobj import ConfigObj
 from ipv8.test.base import TestBase
 
+import tribler.core.libtorrent.restapi.create_torrent_endpoint as ep_module
 from tribler.core.libtorrent.download_manager.download_config import SPEC_CONTENT, DownloadConfig
 from tribler.core.libtorrent.restapi.create_torrent_endpoint import CreateTorrentEndpoint
 from tribler.core.restapi.rest_endpoint import HTTP_BAD_REQUEST, HTTP_INTERNAL_SERVER_ERROR
@@ -71,9 +72,8 @@ class TestCreateTorrentEndpoint(TestBase):
         """
         Test if processing a request that leads to an OSError is gracefully reported.
         """
-        self.download_manager.create_torrent_file = AsyncMock(side_effect=OSError("test"))
-
-        response = await self.endpoint.create_torrent(CreateTorrentRequest({"files": [str(Path(__file__))]}))
+        with patch.dict(ep_module.__dict__, {"create_torrent_file": Mock(side_effect=OSError("test"))}):
+            response = await self.endpoint.create_torrent(CreateTorrentRequest({"files": [str(Path(__file__))]}))
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
@@ -85,9 +85,9 @@ class TestCreateTorrentEndpoint(TestBase):
         """
         Test if processing a request that leads to an OSError is gracefully reported.
         """
-        self.download_manager.create_torrent_file = AsyncMock(side_effect=UnicodeDecodeError("utf-8", b"", 0, 1, "𓀬"))
-
-        response = await self.endpoint.create_torrent(CreateTorrentRequest({"files": [str(Path(__file__))]}))
+        with patch.dict(ep_module.__dict__, {"create_torrent_file":
+                                             Mock(side_effect=UnicodeDecodeError("utf-8", b"", 0, 1, "𓀬"))}):
+            response = await self.endpoint.create_torrent(CreateTorrentRequest({"files": [str(Path(__file__))]}))
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
@@ -98,9 +98,8 @@ class TestCreateTorrentEndpoint(TestBase):
         """
         Test if processing a request that leads to an RuntimeError is gracefully reported.
         """
-        self.download_manager.create_torrent_file = AsyncMock(side_effect=RuntimeError("test"))
-
-        response = await self.endpoint.create_torrent(CreateTorrentRequest({"files": [str(Path(__file__))]}))
+        with patch.dict(ep_module.__dict__, {"create_torrent_file": Mock(side_effect=RuntimeError("test"))}):
+            response = await self.endpoint.create_torrent(CreateTorrentRequest({"files": [str(Path(__file__))]}))
         response_body_json = await response_to_json(response)
 
         self.assertEqual(HTTP_INTERNAL_SERVER_ERROR, response.status)
@@ -112,12 +111,12 @@ class TestCreateTorrentEndpoint(TestBase):
         """
         Test if creating a torrent from defaults works.
         """
-        self.download_manager.create_torrent_file = AsyncMock(return_value={"metainfo": TORRENT_WITH_DIRS_CONTENT})
-
-        response = await self.endpoint.create_torrent(CreateTorrentRequest({"files": [str(Path(__file__))]}))
+        mocked_create_torrent_file = Mock(return_value={"metainfo": TORRENT_WITH_DIRS_CONTENT})
+        with patch.dict(ep_module.__dict__, {"create_torrent_file": mocked_create_torrent_file}):
+            response = await self.endpoint.create_torrent(CreateTorrentRequest({"files": [str(Path(__file__))]}))
         response_body_json = await response_to_json(response)
 
-        _, call_params = self.download_manager.create_torrent_file.call_args.args
+        _, call_params, __ = mocked_create_torrent_file.call_args.args
 
         self.assertEqual(200, response.status)
         self.assertEqual(TORRENT_WITH_DIRS_CONTENT, base64.b64decode(response_body_json["torrent"]))
@@ -130,13 +129,13 @@ class TestCreateTorrentEndpoint(TestBase):
         """
         Test if creating a torrent with a custom comment works.
         """
-        self.download_manager.create_torrent_file = AsyncMock(return_value={"metainfo": TORRENT_WITH_DIRS_CONTENT})
-
-        response = await self.endpoint.create_torrent(CreateTorrentRequest({"files": [str(Path(__file__))],
-                                                                            "description": "test"}))
+        mocked_create_torrent_file = Mock(return_value={"metainfo": TORRENT_WITH_DIRS_CONTENT})
+        with patch.dict(ep_module.__dict__, {"create_torrent_file": mocked_create_torrent_file}):
+            response = await self.endpoint.create_torrent(CreateTorrentRequest({"files": [str(Path(__file__))],
+                                                                                "description": "test"}))
         response_body_json = await response_to_json(response)
 
-        _, call_params = self.download_manager.create_torrent_file.call_args.args
+        _, call_params, __ = mocked_create_torrent_file.call_args.args
 
         self.assertEqual(200, response.status)
         self.assertEqual(TORRENT_WITH_DIRS_CONTENT, base64.b64decode(response_body_json["torrent"]))
@@ -146,14 +145,15 @@ class TestCreateTorrentEndpoint(TestBase):
         """
         Test if creating a torrent with custom trackers works.
         """
-        self.download_manager.create_torrent_file = AsyncMock(return_value={"metainfo": TORRENT_WITH_DIRS_CONTENT})
-
-        response = await self.endpoint.create_torrent(CreateTorrentRequest({"files": [str(Path(__file__))],
-                                                                            "trackers": ["http://127.0.0.1/announce",
-                                                                                         "http://10.0.0.2/announce"]}))
+        mocked_create_torrent_file = Mock(return_value={"metainfo": TORRENT_WITH_DIRS_CONTENT})
+        with patch.dict(ep_module.__dict__, {"create_torrent_file": mocked_create_torrent_file}):
+            response = await self.endpoint.create_torrent(CreateTorrentRequest({
+                "files": [str(Path(__file__))],
+                "trackers": ["http://127.0.0.1/announce", "http://10.0.0.2/announce"]
+            }))
         response_body_json = await response_to_json(response)
 
-        _, call_params = self.download_manager.create_torrent_file.call_args.args
+        _, call_params, __ = mocked_create_torrent_file.call_args.args
 
         self.assertEqual(200, response.status)
         self.assertEqual(TORRENT_WITH_DIRS_CONTENT, base64.b64decode(response_body_json["torrent"]))
@@ -164,13 +164,13 @@ class TestCreateTorrentEndpoint(TestBase):
         """
         Test if creating a torrent with a custom name works.
         """
-        self.download_manager.create_torrent_file = AsyncMock(return_value={"metainfo": TORRENT_WITH_DIRS_CONTENT})
-
-        response = await self.endpoint.create_torrent(CreateTorrentRequest({"files": [str(Path(__file__))],
-                                                                            "name": "test"}))
+        mocked_create_torrent_file = Mock(return_value={"metainfo": TORRENT_WITH_DIRS_CONTENT})
+        with patch.dict(ep_module.__dict__, {"create_torrent_file": mocked_create_torrent_file}):
+            response = await self.endpoint.create_torrent(CreateTorrentRequest({"files": [str(Path(__file__))],
+                                                                                "name": "test"}))
         response_body_json = await response_to_json(response)
 
-        _, call_params = self.download_manager.create_torrent_file.call_args.args
+        _, call_params, __ = mocked_create_torrent_file.call_args.args
 
         self.assertEqual(200, response.status)
         self.assertEqual(TORRENT_WITH_DIRS_CONTENT, base64.b64decode(response_body_json["torrent"]))
@@ -181,19 +181,20 @@ class TestCreateTorrentEndpoint(TestBase):
         Test if creating and starting a download works if download is set to 1.
         """
         self.download_manager.config = MockTriblerConfigManager()
-        self.download_manager.create_torrent_file = AsyncMock(return_value={"metainfo": TORRENT_WITH_DIRS_CONTENT,
-                                                                            "base_dir": str(Path(__file__).parent)})
         self.download_manager.start_download = AsyncMock()
-
+        mocked_create = Mock(return_value={"metainfo": TORRENT_WITH_DIRS_CONTENT,
+                                           "base_dir": str(Path(__file__).parent)})
         with patch("tribler.core.libtorrent.download_manager.download_config.DownloadConfig.from_defaults",
-                   lambda _: DownloadConfig(ConfigObj(StringIO(SPEC_CONTENT)))):
+                   lambda _: DownloadConfig(ConfigObj(StringIO(SPEC_CONTENT)))), patch.dict(ep_module.__dict__,
+                                                                                            {"create_torrent_file":
+                                                                                                 mocked_create}):
             response = await self.endpoint.create_torrent(CreateTorrentRequest({"files": [str(Path(__file__))],
                                                                                 "download": "1"}))
         response_body_json = await response_to_json(response)
 
-        call_kwargs = self.download_manager.start_download.call_args.kwargs
+        _, tdef, __ = self.download_manager.start_download.call_args.args
 
         self.assertEqual(200, response.status)
         self.assertEqual(TORRENT_WITH_DIRS_CONTENT, base64.b64decode(response_body_json["torrent"]))
         self.assertEqual(b"\xb3\xba\x19\xc93\xda\x95\x84k\xfd\xf7Z\xd0\x8a\x94\x9cl\xea\xc7\xbc",
-                         call_kwargs["tdef"].infohash)
+                         tdef.infohash)

--- a/src/tribler/test_unit/core/libtorrent/test_torrentdef.py
+++ b/src/tribler/test_unit/core/libtorrent/test_torrentdef.py
@@ -50,32 +50,6 @@ class TestTorrentDef(TestBase):
         with self.assertRaises(ValueError):
             TorrentDef(metainfo={b"info": {}}, ignore_validation=False)
 
-    def test_add_content_dir(self) -> None:
-        """
-        Test if adding a single content directory with two files is working correctly.
-        """
-        tdef = TorrentDef()
-        torrent_dir = Path(__file__).parent
-        tdef.add_content(torrent_dir / "__init__.py")
-        tdef.add_content(torrent_dir / "mocks.py")
-
-        tdef.save()
-        metainfo = tdef.get_metainfo()
-
-        self.assertEqual(2, len(metainfo[b"info"][b"files"]))
-
-    def test_add_single_file(self) -> None:
-        """
-        Test if adding a single file to a torrent is working correctly.
-        """
-        tdef = TorrentDef()
-        tdef.add_content(Path(__file__))
-
-        tdef.save()
-        metainfo = tdef.get_metainfo()
-
-        self.assertEqual(b"test_torrentdef.py", metainfo[b"info"][b"name"])
-
     def test_get_name_utf8_unknown(self) -> None:
         """
         Test if we can succesfully get the UTF-8 name.
@@ -96,19 +70,6 @@ class TestTorrentDef(TestBase):
         tdef.set_name(b"\xA1\xC0")
 
         self.assertEqual("\xa1\xc0", tdef.get_name_utf8())
-
-    def test_add_content_piece_length(self) -> None:
-        """
-        Test if we can add single file with piece length to a TorrentDef.
-        """
-        tdef = TorrentDef()
-        tdef.add_content(Path(__file__))
-
-        tdef.set_piece_length(2 ** 16)
-        tdef.save()
-        metainfo = tdef.get_metainfo()
-
-        self.assertEqual(2 ** 16, metainfo[b"info"][b"piece length"])
 
     def test_is_private_non_private(self) -> None:
         """


### PR DESCRIPTION
Fixes #45

This PR:

 - Fixes silently failing `ConfigObj.write()`.
 - Removes `DownloadManager.create_torrent_file`.
 - Removes `TorrentDef.files_list`/`TorrentDef.add_content()`/`TorrentDef.save()`.

