### PR TITLE
Validation action fixes

### DIFF
--- a/.github/workflows/pr-comment-validate.yml
+++ b/.github/workflows/pr-comment-validate.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]  # macos-latest not tested due to crashing.
-        version: ["3.8", "3.9", "3.10"]
+        version: ["3.9", "3.10"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -108,4 +108,3 @@ jobs:
           state: 'success'
           sha: ${{ env.actual_pull_head }}
           target_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-

--- a/src/tribler/test_unit/core/rendezvous/test_community.py
+++ b/src/tribler/test_unit/core/rendezvous/test_community.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import socket
 from typing import TYPE_CHECKING
 
@@ -55,7 +56,8 @@ class TestUserActivityCommunity(TestBase[RendezvousCommunity]):
         payload, = received
 
         self.assertEqual(self.key_bin(0), payload.public_key)
-        self.assertEqual(socket.inet_pton(socket.AF_INET, self.address(0)[0]), payload.ip)
+        self.assertEqual(socket.inet_pton(socket.AF_INET6 if int(os.environ.get("TEST_IPV8_WITH_IPV6", "0"))
+                                          else socket.AF_INET, self.address(0)[0]), payload.ip)
         self.assertEqual(self.address(0)[1], payload.port)
         self.assertEqual(0.0, payload.start)
         self.assertEqual(10.0, payload.stop)


### PR DESCRIPTION
Related to #58, the action fixes will have to be verified in another PR.

This PR:

 - Updates the GitHub validation Action to only run on Python 3.9 and Python 3.10.
 - Updates `content_discovery.test_community` to be IPv6 compatible.
 - Updates `rendezvous.test_community` to be IPv6 compatible.


