### PR TITLE
Fixed libsodium.dll cache locations

### DIFF
--- a/.github/workflows/periodic_unittests.yml
+++ b/.github/workflows/periodic_unittests.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/cache/restore@v4
         id: restore_cache
         with:
-          path: libsodium.dll
+          path: src/libsodium.dll
           key: cache_libsodium_dll
       - run: python -m pip install -r requirements.txt
       - name: Run unit tests
@@ -29,5 +29,5 @@ jobs:
       - uses: actions/cache/save@v4
         if: always()  # Even if the tests fail or the job is cancelled, the cache should be refreshed
         with:
-          path: libsodium.dll
+          path: src/libsodium.dll
           key: cache_libsodium_dll

--- a/.github/workflows/pr-comment-validate.yml
+++ b/.github/workflows/pr-comment-validate.yml
@@ -27,7 +27,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         id: restore_cache
         with:
-          path: libsodium.dll
+          path: src/libsodium.dll
           key: cache_libsodium_dll
       - run: python -m pip install -r requirements.txt
       - run: |
@@ -40,12 +40,6 @@ jobs:
           python run_unit_tests.py -a
         env:
           TEST_IPV8_WITH_IPV6: 1
-      - uses: actions/cache/save@v4
-        if: matrix.os == 'windows-latest'
-        id: save_cache
-        with:
-          path: libsodium.dll
-          key: cache_libsodium_dll
 
   set_pending_status:
     if: ${{github.event.issue.pull_request && startsWith(github.event.comment.body, 'validate') }}

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/cache/restore@v4
         id: restore_cache
         with:
-          path: libsodium.dll
+          path: src/libsodium.dll
           key: cache_libsodium_dll
       - run: python -m pip install -r requirements.txt
       - name: Run unit tests


### PR DESCRIPTION
Fixes #61

This PR:

 - Fixes the cache locations of `libsodium.dll` in the GitHub actions.

_Disclaimer: there is a chance that my intuition in #61 is totally wrong. In the worst case, this will remain broken._
