### PR TITLE
Fixed missing middleware and incorrect API key

### DIFF
--- a/.github/workflows/pr-comment-validate.yml
+++ b/.github/workflows/pr-comment-validate.yml
@@ -40,11 +40,9 @@ jobs:
           python run_unit_tests.py -a
         env:
           TEST_IPV8_WITH_IPV6: 1
-      - shell: pwsh  # force inferior operating systems to use the glorious Windows PowerShell
-        run: |
+      - run: |
           cd src
-          $env:PYTHONPATH = "../pyipv8"
-          python -m unittest -k tribler.test_integration
+          python run_unit_tests.py -a -k tribler/test_integration -p 2
 
   set_pending_status:
     if: ${{github.event.issue.pull_request && startsWith(github.event.comment.body, 'validate') }}

--- a/src/run_unit_tests.py
+++ b/src/run_unit_tests.py
@@ -40,6 +40,8 @@ if __name__ == "__main__":
                         help="Don't animate the terminal output.")
     parser.add_argument("-d", "--nodownload", action="store_true", required=False,
                         help="Don't attempt to download missing dependencies.")
+    parser.add_argument("-k", "--pattern", type=str, default="tribler/test_unit", required=False,
+                        help="The unit test directory.")
     args = parser.parse_args()
 
     if platform.system() == "Windows" and windows_missing_libsodium() and not args.nodownload:
@@ -48,7 +50,7 @@ if __name__ == "__main__":
         os.add_dll_directory(str(pathlib.Path("libsodium.dll").absolute().parent))
 
     process_count = args.processes
-    test_class_names = find_all_test_class_names(pathlib.Path("tribler/test_unit"))
+    test_class_names = find_all_test_class_names(pathlib.Path(args.pattern))
 
     total_start_time = time.time()
     total_end_time = time.time()

--- a/src/tribler/core/restapi/rest_manager.py
+++ b/src/tribler/core/restapi/rest_manager.py
@@ -113,7 +113,7 @@ class RESTManager:
         """
         super().__init__()
         self._logger = logging.getLogger(self.__class__.__name__)
-        self.root_endpoint = RootEndpoint()
+        self.root_endpoint = RootEndpoint(middlewares=(ApiKeyMiddleware(config.get("api/key")), error_middleware))
         self.runner: web.AppRunner | None = None
         self.site: web.TCPSite | None = None
         self.site_https: web.TCPSite | None = None

--- a/src/tribler/core/start_core.py
+++ b/src/tribler/core/start_core.py
@@ -40,7 +40,7 @@ def run_core(api_port: int, api_key: str | None, state_dir: Path) -> None:
         config.set("api/http_port", 0)
         config.set("api/https_port", 0)
 
-    if api_key is None:
+    if api_key != config.get("api/key"):
         config.set("api/key", api_key)
         config.write()
 


### PR DESCRIPTION
Fixes #65

This PR:

 - Fixes the `RootEndpoint` not initializing the middlewares.
 - Fixes the API key not being written to the config (unless it was `None`).
 - Fixes the validation action not finding `libsodium.dll`.
 - Updates the unit test runner to allow other directories.

