### PR TITLE
Register REST Endpoints before initializing them

### DIFF
--- a/src/tribler/core/restapi/statistics_endpoint.py
+++ b/src/tribler/core/restapi/statistics_endpoint.py
@@ -1,11 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from aiohttp import web
 from aiohttp_apispec import docs
 from ipv8.REST.schema import schema
-from ipv8.types import IPv8
 from marshmallow.fields import Integer, String
 
-from tribler.core.database.store import MetadataStore
-from tribler.core.restapi.rest_endpoint import RESTEndpoint, RESTResponse
+from tribler.core.restapi.rest_endpoint import MAX_REQUEST_SIZE, RESTEndpoint, RESTResponse
+
+if TYPE_CHECKING:
+    from ipv8.types import IPv8
+
+    from tribler.core.database.store import MetadataStore
 
 
 class StatisticsEndpoint(RESTEndpoint):
@@ -15,13 +22,15 @@ class StatisticsEndpoint(RESTEndpoint):
 
     path = "/statistics"
 
-    def __init__(self, ipv8: IPv8 = None, metadata_store: MetadataStore = None) -> None:
+    def __init__(self, middlewares: tuple = (), client_max_size: int = MAX_REQUEST_SIZE) -> None:
         """
         Create a new statistics endpoint.
         """
-        super().__init__()
-        self.mds = metadata_store
-        self.ipv8 = ipv8
+        super().__init__(middlewares, client_max_size)
+
+        self.mds: MetadataStore | None = None
+        self.ipv8: IPv8 | None = None
+
         self.app.add_routes([web.get("/tribler", self.get_tribler_stats),
                              web.get("/ipv8", self.get_ipv8_stats)])
 

--- a/src/tribler/test_unit/core/content_discovery/restapi/test_search_endpoint.py
+++ b/src/tribler/test_unit/core/content_discovery/restapi/test_search_endpoint.py
@@ -43,6 +43,7 @@ class SearchRequest(MockRequest):
         Create a new SearchRequest.
         """
         super().__init__(query, "PUT", "/search/remote")
+        self.context = [MockContentDiscoveryCommunity()]
 
 
 class TestSearchEndpoint(TestBase):
@@ -54,7 +55,7 @@ class TestSearchEndpoint(TestBase):
         """
         Test if a bad request returns the bad request status.
         """
-        endpoint = SearchEndpoint(MockContentDiscoveryCommunity())
+        endpoint = SearchEndpoint()
 
         response = await endpoint.remote_search(SearchRequest({"channel_pk": "GG"}))
 
@@ -64,7 +65,7 @@ class TestSearchEndpoint(TestBase):
         """
         Test if a good search request returns a dict with the UUID and serving peers.
         """
-        endpoint = SearchEndpoint(MockContentDiscoveryCommunity())
+        endpoint = SearchEndpoint()
 
         response = await endpoint.remote_search(SearchRequest({"channel_pk": "AA", "fts_text": ""}))
         response_body_json = await response_to_json(response)


### PR DESCRIPTION
Fixes #25

This PR:

 - Updates the REST endpoints to initialize with all "heavy" components set to `None`.

This functionality allows us to query the core while it is initializing (for example `ipv8/asyncio/tasks` to check for hanging asyncio calls).
