### PR TITLE
Fix Mac build script using old pip

### DIFF
--- a/build/mac/makedist_macos.sh
+++ b/build/mac/makedist_macos.sh
@@ -22,6 +22,7 @@ export RESOURCES=build/mac/resources
 
 python3 -m venv "${BUILD_ENV}"
 . "${BUILD_ENV}"/bin/activate
+python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade -r requirements-build.txt
 
 # ----- Build


### PR DESCRIPTION
This PR:

 - Fixes the Mac builder running an outdated version of pip.
