### PR TITLE
Added extended type checking with the libtorrent API

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -12,4 +12,6 @@ jobs:
       - name: Install mypy
         run: pip install mypy
       - name: Run mypy
-        run: mypy -p src.tribler.core
+        run: |
+          wget -O libtorrent.pyi https://github.com/arvidn/libtorrent/raw/master/bindings/python/install_data/libtorrent/__init__.pyi
+          mypy -p src.tribler.core

--- a/src/tribler/core/libtorrent/download_manager/download_config.py
+++ b/src/tribler/core/libtorrent/download_manager/download_config.py
@@ -89,11 +89,16 @@ def _from_dict(value: Dict) -> str:
     return base64_bytes.decode()
 
 
-def _to_dict(value: str) -> dict | None:
+def _to_dict(value: str) -> dict[bytes, Any]:
+    """
+    Convert a string value to a libtorrent dict.
+
+    :raises RuntimeError: if the value could not be converted.
+    """
     binary = value.encode()
     # b'==' is added to avoid incorrect padding
     base64_bytes = base64.b64decode(binary + b"==")
-    return lt.bdecode(base64_bytes)
+    return cast(dict[bytes, Any], lt.bdecode(base64_bytes))
 
 
 class DownloadConfig:

--- a/src/tribler/core/libtorrent/restapi/libtorrent_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/libtorrent_endpoint.py
@@ -97,7 +97,7 @@ class LibTorrentEndpoint(RESTEndpoint):
         """
         session_stats: Future[dict[str, int]] = Future()
 
-        def on_session_stats_alert_received(alert: libtorrent.alert) -> None:
+        def on_session_stats_alert_received(alert: libtorrent.session_stats_alert) -> None:
             if not session_stats.done():
                 session_stats.set_result(alert.values)
 

--- a/src/tribler/core/libtorrent/restapi/torrentinfo_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/torrentinfo_endpoint.py
@@ -161,7 +161,7 @@ class TorrentInfoEndpoint(RESTEndpoint):
                 try:
                     try:
                         # libtorrent 1.2.19
-                        infohash = lt.parse_magnet_uri(uri)["info_hash"]
+                        infohash = lt.parse_magnet_uri(uri)["info_hash"]  # type: ignore[index] # (checker uses 2.X)
                     except TypeError:
                         # libtorrent 2.0.9
                         infohash = unhexlify(str(lt.parse_magnet_uri(uri).info_hash))
@@ -181,7 +181,7 @@ class TorrentInfoEndpoint(RESTEndpoint):
             try:
                 try:
                     # libtorrent 1.2.19
-                    infohash = lt.parse_magnet_uri(uri)["info_hash"]
+                    infohash = lt.parse_magnet_uri(uri)["info_hash"]  # type: ignore[index] # (checker uses 2.X)
                 except TypeError:
                     # libtorrent 2.0.9
                     infohash = unhexlify(str(lt.parse_magnet_uri(uri).info_hash))

--- a/src/tribler/core/libtorrent/torrents.py
+++ b/src/tribler/core/libtorrent/torrents.py
@@ -124,7 +124,7 @@ class TorrentFileResult(TypedDict):
     success: bool
     base_dir: Path
     torrent_file_path: str | None
-    metainfo: dict
+    metainfo: bytes
     infohash: bytes
 
 
@@ -185,17 +185,17 @@ def create_torrent_file(file_path_list: list[Path], params: InfoDict,  # noqa: C
     lt.set_piece_hashes(torrent, str(base_dir))
 
     t1 = torrent.generate()
-    torrent = lt.bencode(t1)
+    torrent_bytes = lt.bencode(t1)
 
     if torrent_filepath:
         with open(torrent_filepath, "wb") as f:
-            f.write(torrent)
+            f.write(torrent_bytes)
 
     return {
         "success": True,
         "base_dir": base_dir,
         "torrent_file_path": torrent_filepath,
-        "metainfo": torrent,
+        "metainfo": torrent_bytes,
         "infohash": sha1(lt.bencode(t1[b"info"])).digest()
     }
 


### PR DESCRIPTION
Fixes #40

This PR:

 - Adds fetching the libtorrent type stubs when performing the unittest mypy check.
 - Fixes the typing errors related to libtorrent.

Note that this PR also makes TriblerExperimental libtorrent 2.X compatible. At least, according to the typing.

