### PR TITLE
Fix for not being able to download non-anonymously

### DIFF
--- a/src/tribler/core/libtorrent/restapi/downloads_endpoint.py
+++ b/src/tribler/core/libtorrent/restapi/downloads_endpoint.py
@@ -106,7 +106,7 @@ class DownloadsEndpoint(RESTEndpoint):
         if anon_hops > 0 and not safe_seeding:
             return None, "Cannot set anonymous download without safe seeding enabled"
 
-        if anon_hops > 0:
+        if anon_hops >= 0:
             download_config.set_hops(anon_hops)
 
         if safe_seeding:


### PR DESCRIPTION
It's currently not possible to start a download non-anonymously. This is due to `create_dconfig_from_params` creating the config from the defaults, and subsequently only setting the hop count if >0. The default hop count on the main repo is 0, so there's no issue there.