### PR TITLE
Fix TorrentDef.get_length

### DIFF
--- a/src/tribler/core/libtorrent/torrentdef.py
+++ b/src/tribler/core/libtorrent/torrentdef.py
@@ -165,7 +165,7 @@ def pathlist2filename(pathlist: Iterable[bytes]) -> Path:
     return Path(*(x.decode() for x in pathlist))
 
 
-def get_length_from_metainfo(metainfo: MetainfoDict, selectedfiles: set[Path]) -> int:
+def get_length_from_metainfo(metainfo: MetainfoDict, selectedfiles: set[Path] | None) -> int:
     """
     Loop through all files in a torrent and calculate the total size.
     """
@@ -592,7 +592,7 @@ class TorrentDef:
 
         :return: A length (long)
         """
-        if self.metainfo and selectedfiles is not None:
+        if self.metainfo:
             return get_length_from_metainfo(self.metainfo, selectedfiles)
         return 0
 


### PR DESCRIPTION
This PR fixes a bug with `TorrentDef.get_metainfo()` returning 0. This causes many torrents in the GUI and database to have 0 length. I've also seen 0 length torrents popping up on Tribler main, which is probably because the size is getting gossiped.
