### PR TITLE
Configure IPv6 to be enabled by default

### DIFF
--- a/src/tribler/tribler_config.py
+++ b/src/tribler/tribler_config.py
@@ -212,6 +212,11 @@ DEFAULT_CONFIG = {
 }
 
 # Changes to IPv8 default config
+DEFAULT_CONFIG["ipv8"]["interfaces"].append({
+    "interface": "UDPIPv6",
+    "ip": "::",
+    "port": 8091
+})
 DEFAULT_CONFIG["ipv8"]["keys"].append({
     'alias': "secondary",
     'generation': "curve25519",


### PR DESCRIPTION
Fixes #96

This PR:

 - Adds IPv6 support in the default configuration.

Notes:
 - If IPv6 is not supported by the platform, IPv8 should disable it automatically.
 - This is just the default: the configuration can still be changed to disable IPv6 again.